### PR TITLE
Temporarily run integration tests just on linux

### DIFF
--- a/.github/workflows/fork-integration-test.yml
+++ b/.github/workflows/fork-integration-test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest]
     steps:
 
       - name: Set up Go 1.x


### PR DESCRIPTION
This commit changes the workflow which test executed when building
integration tests of PRs coming from forks (Run Integration Tests
for Forks). It temporarily disables builds to run on MacOS and Windows.

The reason for that is #30, builds are currently failing on windows.
Furthermore, there seems to be a problem with concurrent integration
test execution.

We should revert this change again anlongside the fix for #30.