### PR TITLE
Fix issue when parallel integrations tests are failing on kubernetes credentials

### DIFF
--- a/cmd/monaco/test-resources/integration-all-configs/project/kubernetes-credentials/kubernetes.json
+++ b/cmd/monaco/test-resources/integration-all-configs/project/kubernetes-credentials/kubernetes.json
@@ -1,9 +1,9 @@
 {
     "active": "{{ .active }}",
     "label": "{{ .name }}",
-    "endpointUrl": "{{ .endpoint }}",
+    "endpointUrl": "https://{{ urlquery .name }}/",
     "authToken": "{{ .token }}",
     "eventsIntegrationEnabled": true,
     "workloadIntegrationEnabled": true,
     "certificateCheckEnabled": false
-  }
+}


### PR DESCRIPTION
As `endpointUrl` needs to be unique, used name (which is generated with timestamp). Using hardcoded `endpointUrl` results in error 
```JSON 
{"error":{"code":400,"message":"Constraints violated.","constraintViolations":[{"path":"endpointUrl","message":"URL is already in use.","parameterLocation":"PAYLOAD_BODY","location":null}]}}
```
Using `name` instead of hardcoded url, because it also contains timestamp when test is started, meaning `endpointUrl` will be different every time tests are executed.