### PR TITLE
Fix: Set console/file multilogger as shared logger

### DIFF
--- a/pkg/util/logging.go
+++ b/pkg/util/logging.go
@@ -47,6 +47,7 @@ func SetupLogging(verbose bool) error {
 	if err == nil {
 		fileLog.Level(lumber.DEBUG)
 		multiLog.AddLoggers(fileLog)
+		Log = multiLog
 	}
 	return err
 }


### PR DESCRIPTION
Actually assign the MultiLogger created in SetupLogging(),
to the shared Log object.

As implemented now, still defaults to non-verbose Console logging,
unless both console and file logging setup works.

Fix #43

@tatomir146 , @didiladi mea culpa...