### PR TITLE
Add issue template for reporting BUGs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**How to reproduce**
+Steps to reproduce the behavior:
+- environments files
+- Yaml config
+- JSON template
+- Flags used to execute tool
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Log output**
+If applicable, add log snippet to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS: [e.g. Win 10, Ubuntu Linux, macOs Catalina]
+ - Tool version [e.g. 1.0.1]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Let's add our first issue template for BUGs. Please feel free to propose changes.

PS once we are happy with templates, we can also think about deactivating default blank template.