### PR TITLE
Fix unresolved references errors in GoLand (#52)

### DIFF
--- a/cmd/monaco/all_configs_integration_test.go
+++ b/cmd/monaco/all_configs_integration_test.go
@@ -25,21 +25,19 @@ import (
 	"gotest.tools/assert"
 )
 
-const allConfigsFolder = "test-resources/integration-all-configs/"
-const allConfigsEnvironmentsFile = allConfigsFolder + "environments.yaml"
-
 // tests all configs for a single environment
 func TestIntegrationAllConfigs(t *testing.T) {
 
-	RunIntegrationWithCleanup(t, "AllConfigs", func(transformers []func(string) string) {
-		var integrationTestReader, err = util.NewInMemoryFileReader(allConfigsFolder, transformers)
-		assert.NilError(t, err)
+	const allConfigsFolder = "test-resources/integration-all-configs/"
+	const allConfigsEnvironmentsFile = allConfigsFolder + "environments.yaml"
+
+	RunIntegrationWithCleanup(t, allConfigsFolder, allConfigsEnvironmentsFile, "AllConfigs", func(fileReader util.FileReader) {
 
 		statusCode := RunImpl([]string{
 			"monaco",
 			"--environments", allConfigsEnvironmentsFile,
 			allConfigsFolder,
-		}, integrationTestReader)
+		}, fileReader)
 
 		assert.Equal(t, statusCode, 0)
 	})

--- a/cmd/monaco/multi_project_integration_test.go
+++ b/cmd/monaco/multi_project_integration_test.go
@@ -34,9 +34,7 @@ const multiProjectEnvironmentsFile = multiProjectFolder + "environments.yaml"
 // Tests all environments with all projects
 func TestIntegrationMultiProject(t *testing.T) {
 
-	RunIntegrationWithCleanup(t, "MultiProject", func(transformers []func(string) string) {
-		var integrationTestReader, err = util.NewInMemoryFileReader(multiProjectFolder, transformers)
-		assert.NilError(t, err)
+	RunIntegrationWithCleanup(t, multiProjectFolder, multiProjectEnvironmentsFile, "MultiProject", func(integrationTestReader util.FileReader) {
 
 		environments, errs := environment.LoadEnvironmentList("", multiProjectEnvironmentsFile, integrationTestReader)
 		assert.Check(t, len(errs) == 0, "didn't expect errors loading test environments")
@@ -72,9 +70,7 @@ func TestIntegrationValidationMultiProject(t *testing.T) {
 // tests a single project with dependencies
 func TestIntegrationMultiProjectSingleProject(t *testing.T) {
 
-	RunIntegrationWithCleanup(t, "MultiProjectSingleProject", func(transformers []func(string) string) {
-		var integrationTestReader, err = util.NewInMemoryFileReader(multiProjectFolder, transformers)
-		assert.NilError(t, err)
+	RunIntegrationWithCleanup(t, multiProjectFolder, multiProjectEnvironmentsFile, "MultiProjectSingleProject", func(integrationTestReader util.FileReader) {
 
 		environments, errs := environment.LoadEnvironmentList("", multiProjectEnvironmentsFile, integrationTestReader)
 		FailOnAnyError(errs, "loading of environments failed")

--- a/cmd/monaco/multi_tenant_integration_test.go
+++ b/cmd/monaco/multi_tenant_integration_test.go
@@ -35,10 +35,7 @@ const environmentsFile = folder + "environments.yaml"
 // Tests all environments with all projects
 func TestIntegrationMultiEnvironment(t *testing.T) {
 
-	RunIntegrationWithCleanup(t, "MultiEnvironment", func(transformers []func(string) string) {
-
-		var integrationTestReader, err = util.NewInMemoryFileReader(folder, transformers)
-		assert.NilError(t, err)
+	RunIntegrationWithCleanup(t, folder, environmentsFile, "MultiEnvironment", func(integrationTestReader util.FileReader) {
 
 		environments, errs := environment.LoadEnvironmentList("", environmentsFile, integrationTestReader)
 		assert.Check(t, len(errs) == 0, "didn't expect errors loading test environments")
@@ -74,9 +71,7 @@ func TestIntegrationValidationMultiEnvironment(t *testing.T) {
 // tests a single project
 func TestIntegrationMultiEnvironmentSingleProject(t *testing.T) {
 
-	RunIntegrationWithCleanup(t, "MultiEnvironmentSingleProject", func(transformers []func(string) string) {
-		var integrationTestReader, err = util.NewInMemoryFileReader(folder, transformers)
-		assert.NilError(t, err)
+	RunIntegrationWithCleanup(t, folder, environmentsFile, "MultiEnvironmentSingleProject", func(integrationTestReader util.FileReader) {
 
 		environments, errs := environment.LoadEnvironmentList("", environmentsFile, integrationTestReader)
 		FailOnAnyError(errs, "loading of environments failed")
@@ -100,9 +95,7 @@ func TestIntegrationMultiEnvironmentSingleProject(t *testing.T) {
 // Tests a single project with dependency
 func TestIntegrationMultiEnvironmentSingleProjectWithDependency(t *testing.T) {
 
-	RunIntegrationWithCleanup(t, "MultiEnvironmentSingleProjectWithDependency", func(transformers []func(string) string) {
-		var integrationTestReader, err = util.NewInMemoryFileReader(folder, transformers)
-		assert.NilError(t, err)
+	RunIntegrationWithCleanup(t, folder, environmentsFile, "MultiEnvironmentSingleProjectWithDependency", func(integrationTestReader util.FileReader) {
 
 		environments, errs := environment.LoadEnvironmentList("", environmentsFile, integrationTestReader)
 		FailOnAnyError(errs, "loading of environments failed")
@@ -128,9 +121,7 @@ func TestIntegrationMultiEnvironmentSingleProjectWithDependency(t *testing.T) {
 // tests a single environment
 func TestIntegrationMultiEnvironmentSingleEnvironment(t *testing.T) {
 
-	RunIntegrationWithCleanup(t, "MultiEnvironmentSingleEnvironment", func(transformers []func(string) string) {
-		var integrationTestReader, err = util.NewInMemoryFileReader(folder, transformers)
-		assert.NilError(t, err)
+	RunIntegrationWithCleanup(t, folder, environmentsFile, "MultiEnvironmentSingleEnvironment", func(integrationTestReader util.FileReader) {
 
 		environments, errs := environment.LoadEnvironmentList("", environmentsFile, integrationTestReader)
 		FailOnAnyError(errs, "loading of environments failed")


### PR DESCRIPTION
This commit fixes the following issues listed in #52:

  * Unresolved references due to the variables `folder` and
    `environmentsFile` being defined in file
    `multi_tenant_integration_test.go`. They can be seen when opening
    the project in GoLand.
  * We create configs for different environments, as we try to clean
    after running the integration tests.
  * We try to clean up different configs, as we apply in the
    integration test run.

Furthermore, the method `RunIntegrationWithCleanup` was simplified to
take a `func(integrationTestReader util.FileReader) {}`. This
simplifies the integration tests, because the `InMemoryFileReader` is
created in the utility function and passed to the test itself. So, the
individual test doesn't need to create a `FileReader` anymore.

Additionally, some documentation was added to the function
`RunIntegrationWithCleanup`.

fixes #52 