### PR TITLE
Fix the synthetic location id used in the integration tests

### DIFF
--- a/cmd/monaco/test-resources/integration-all-configs/project/synthetic-monitor/synthetic-monitors.yaml
+++ b/cmd/monaco/test-resources/integration-all-configs/project/synthetic-monitor/synthetic-monitors.yaml
@@ -3,7 +3,7 @@ config:
 
 availability:
   - name: "Federation Availability"
-  - location: "GEOLOCATION-DD9455EF49BF2F89"
+  - location: "GEOLOCATION-45AB48D9D6925ECC"
   - managementZoneId: "/project/management-zone/zone.id"
   - tag: "/project/auto-tag/application-tagging.name"
   - host: "https://www.google.com"


### PR DESCRIPTION
The all configs integration test currently fails, because the id of the
synthetic location is not existing for the environments, we run the
integration tests for. This was caused by switching out the
environments we run the integration tests against.

fixes #63