### PR TITLE
Log a warning if project name clashes with API name (#58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Also applies to the `SERVICE` type. eg.
 ### Configuration Types / APIs
 
 Each such type folder must contain one `configuration yaml` and one or more `json` files containing the actual configuration send to the Dynatrace API.
+The folder name is case-sensitive and needs to be written exactly as in its definition in [Supported Configuration Types](#supported-configuration-types).
 
 e.g.
 ```


### PR DESCRIPTION
This commit introduces a log message if the project folder name clashes
with an API folder of the same name, but different lowercase/uppercase
spelling. Additionally, the readme was changed, to indicate that API
folders need to be defined case-sensitive.

Example of a log line:
```
2020-11-30 10:43:07 WARN  Project Application in folder \
skip-deployment-project clashes with API name application. \
Consider using a different name for your project.
```

fixes #58