### PR TITLE
Delete configs only if apply finished without errors (#20)

### DIFF
--- a/cmd/monaco/main.go
+++ b/cmd/monaco/main.go
@@ -104,9 +104,8 @@ func RunImpl(args []string, fileReader util.FileReader) (statusCode int) {
 		} else {
 			util.Log.Info("Deployment finished without errors")
 		}
+		deleteConfigs(apis, environments, path, dryRun, fileReader)
 	}
-
-	deleteConfigs(apis, environments, path, dryRun, fileReader)
 
 	return statusCode
 }


### PR DESCRIPTION
This commit deletes configs only if there were no errors during previous deployment/validation.

fixes #20 