### PR TITLE
Fix #80 and #93: Allow trailing slash in folder on Windows

### DIFF
--- a/cmd/monaco/main.go
+++ b/cmd/monaco/main.go
@@ -186,9 +186,9 @@ func readPath(args []string, fileReader util.FileReader) string {
 	// Check for path at the end:
 	potentialPath := args[len(args)-1]
 	if !strings.HasSuffix(potentialPath, ".yaml") {
+		potentialPath = util.ReplacePathSeparators(potentialPath)
 		_, err := fileReader.ReadDir(potentialPath)
 		if err == nil {
-			potentialPath = util.ReplacePathSeparators(potentialPath)
 			if !strings.HasSuffix(potentialPath, string(os.PathSeparator)) {
 				potentialPath += string(os.PathSeparator)
 			}

--- a/cmd/monaco/main.go
+++ b/cmd/monaco/main.go
@@ -188,6 +188,7 @@ func readPath(args []string, fileReader util.FileReader) string {
 	if !strings.HasSuffix(potentialPath, ".yaml") {
 		_, err := fileReader.ReadDir(potentialPath)
 		if err == nil {
+			potentialPath = util.ReplacePathSeparators(potentialPath)
 			if !strings.HasSuffix(potentialPath, string(os.PathSeparator)) {
 				potentialPath += string(os.PathSeparator)
 			}

--- a/cmd/monaco/main_test.go
+++ b/cmd/monaco/main_test.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/dynatrace-oss/dynatrace-monitoring-as-code/pkg/api"
@@ -76,6 +77,28 @@ func TestReadPathNoPath(t *testing.T) {
 
 	path := readPath([]string{"monaco", "--environments", "my-file.yaml"}, util.NewFileReader())
 	assert.Equal(t, path, "")
+}
+
+func TestReadPathTrailingSlashIsReplacedByOSPathSeparator(t *testing.T) {
+	path := readPath([]string{"monaco", "--environments", "my-file.yaml", "test-resources/"}, util.NewFileReader())
+	assert.Equal(t, path, "test-resources"+string(os.PathSeparator))
+}
+
+func TestReadPathTrailingBackslashIsReplacedByOSPathSeparator(t *testing.T) {
+	path := readPath([]string{"monaco", "--environments", "my-file.yaml", `test-resources\`}, util.NewFileReader())
+	assert.Equal(t, path, "test-resources"+string(os.PathSeparator))
+}
+
+func TestReadPathMultipleSlashesAreReplacedByOSPathSeparator(t *testing.T) {
+	path := readPath([]string{"monaco", "--environments", "my-file.yaml", "test-resources/integration-multi-project/"}, util.NewFileReader())
+	result := strings.Count(path, string(os.PathSeparator))
+	assert.Equal(t, result, 2)
+}
+
+func TestReadPathMultipleBackslashesAreReplacedByOSPathSeparator(t *testing.T) {
+	path := readPath([]string{"monaco", "--environments", "my-file.yaml", `test-resources\integration-multi-project\`}, util.NewFileReader())
+	result := strings.Count(path, string(os.PathSeparator))
+	assert.Equal(t, result, 2)
 }
 
 func testGetExecuteApis() map[string]api.Api {


### PR DESCRIPTION
When parsing the command line arguments make sure that any slashes or
backslashes are always replaced by the OS-specific path separator.

Fixes both bugs/issues #80 and #90.