### PR TITLE
Add --version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ Multiple projects can be specified as well:
 
 ```-p="project1,project2,project3"```
 
+In order to get the version of the binary simply execute: 
+```sh
+monaco --version
+```
+
+*NOTE:* If the `--version` flag is present it will *ONLY* print the version and then exit. *ANY OTHER FLAG WILL BE IGNORED*.
+
 The supported flags are described below:
 
 ```
@@ -94,6 +101,8 @@ The supported flags are described below:
   -v    Set verbose flag to enable debug logging. (shorthand)
   -verbose
         Set verbose flag to enable debug logging.
+  -version
+        Prints the current version of the tool and exits the program
 ```
 
 #### Dry Run (Validating Configuration)

--- a/cmd/monaco/main.go
+++ b/cmd/monaco/main.go
@@ -44,7 +44,21 @@ func Run(args []string) int {
 	return RunImpl(args, util.NewFileReader())
 }
 
+func containsVersionFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--version" || arg == "-version" {
+			return true
+		}
+	}
+
+	return false
+}
+
 func RunImpl(args []string, fileReader util.FileReader) (statusCode int) {
+	if containsVersionFlag(args) {
+		fmt.Println(version.MonitoringAsCode)
+		return 0
+	}
 
 	statusCode = 0
 
@@ -115,6 +129,7 @@ func parseInputCommand(args []string, fileReader util.FileReader) (dryRun bool, 
 	// define flags
 	var environmentsFile string
 	var specificEnvironment string
+	var versionFlag bool
 
 	// parse flags
 	shorthand := " (shorthand)"
@@ -140,6 +155,9 @@ func parseInputCommand(args []string, fileReader util.FileReader) (dryRun bool, 
 	flagSet.StringVar(&environmentsFile, "environments", "", environmentsUsage)
 	flagSet.StringVar(&environmentsFile, "e", "", environmentsUsage+shorthand)
 
+	versionUsage := "Prints the current version of the tool and exits"
+	flagSet.BoolVar(&versionFlag, "version", false, versionUsage)
+
 	err := flagSet.Parse(args[1:])
 	if err != nil {
 		return dryRun, verbose, environments, project, path, nil, err
@@ -157,7 +175,8 @@ func parseInputCommand(args []string, fileReader util.FileReader) (dryRun bool, 
 				"\tmonaco --dry-run --environments <path-to-environment-yaml-file> --project <project-folder> [projects-root-folder] \n" +
 				"\tmonaco --environments <path-to-environment-yaml-file> --project <project-folder> [projects-root-folder] \n" +
 				"\tmonaco --specific-environment <environment-name> --project <project-folder> [projects-root-folder] \n" +
-				"\tmonaco --project <project-folder> [projects-root-folder] --environments <path-to-environment-yaml-file> \n"
+				"\tmonaco --project <project-folder> [projects-root-folder] --environments <path-to-environment-yaml-file> \n" +
+				"\tmonaco --version\n"
 
 		examples :=
 			"Examples:\n" +

--- a/cmd/monaco/main_test.go
+++ b/cmd/monaco/main_test.go
@@ -139,6 +139,24 @@ func TestExecutePassOnDuplicateNamesInDifferentEnvironments(t *testing.T) {
 	assert.NilError(t, err)
 }
 
+func TestContainsVersionFlagReturnsTrueWhenFlagIsPresent(t *testing.T) {
+	result := containsVersionFlag([]string{"monaco", "--version"})
+
+	assert.Assert(t, result)
+}
+
+func TestContainsVersionFlagReturnsTrueWhenFlagIsPresentEvenWithOtherFlags(t *testing.T) {
+	result := containsVersionFlag([]string{"monaco", "--dry-run", "--version"})
+
+	assert.Assert(t, result)
+}
+
+func TestContainsVersionFlagReturnsFalseWhenFlagIsNotPresent(t *testing.T) {
+	result := containsVersionFlag([]string{"monaco", "--dry-run"})
+
+	assert.Assert(t, !result)
+}
+
 // TODO (CDF-6511) Currently here UnmarshallYaml logs fatal, only ever returns nil errors!
 // func TestInvalidEnvironmentFileResultsInError(t *testing.T) {
 // 	_, err := environment.LoadEnvironmentList("", "test-resources/invalid-environmentsfile.yaml")


### PR DESCRIPTION
This flags allow you to query the current version of monaco. If the
version flag is present, it will only print the version and the exit the
program.

Fixes #84