### PR TITLE
Always transform references to absolute paths

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -237,13 +237,13 @@ func (c *configImpl) replaceDependencies(data map[string]map[string]string, dict
 }
 
 func (c *configImpl) parseDependency(dependency string, dict map[string]api.DynatraceEntity) (string, error) {
-	absolutePath := false
+	absoluteFromProjectRoot := false
 
 	// in case of an absolute path within the dependency:
 	if strings.HasPrefix(dependency, string(os.PathSeparator)) {
 		// remove prefix "/"
 		dependency = dependency[1:]
-		absolutePath = true
+		absoluteFromProjectRoot = true
 	}
 
 	id, access, err := splitDependency(dependency)
@@ -251,7 +251,7 @@ func (c *configImpl) parseDependency(dependency string, dict map[string]api.Dyna
 		return "", err
 	}
 
-	if !absolutePath {
+	if !absoluteFromProjectRoot {
 		id = filepath.Join(c.project, id)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -236,17 +237,24 @@ func (c *configImpl) replaceDependencies(data map[string]map[string]string, dict
 }
 
 func (c *configImpl) parseDependency(dependency string, dict map[string]api.DynatraceEntity) (string, error) {
+	absolutePath := false
 
 	// in case of an absolute path within the dependency:
 	if strings.HasPrefix(dependency, string(os.PathSeparator)) {
 		// remove prefix "/"
 		dependency = dependency[1:]
+		absolutePath = true
 	}
 
 	id, access, err := splitDependency(dependency)
 	if err != nil {
 		return "", err
 	}
+
+	if !absolutePath {
+		id = filepath.Join(c.project, id)
+	}
+
 	dtObject, ok := dict[id]
 	if !ok {
 		return "", errors.New("Id '" + id + "' was not available. Please make sure the reference exists.")
@@ -372,7 +380,7 @@ func (c *configImpl) GetFilePath() string {
 
 // GetFullQualifiedId returns the full qualified id of the config based on project, api and config id
 func (c *configImpl) GetFullQualifiedId() string {
-	return strings.Join([]string{c.GetProject(), c.GetApi().GetId(), c.GetId()}, string(os.PathSeparator))
+	return filepath.Join(c.GetProject(), c.GetApi().GetId(), c.GetId())
 }
 
 // NewConfig creates a new Config

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -459,7 +459,7 @@ func TestParseDependencyWithRelativePath(t *testing.T) {
 		Id:          "zone",
 	}
 	dict := make(map[string]api.DynatraceEntity)
-	dict["infrastructure/management-zone/zone"] = dynatraceEntity
+	dict["testproject/infrastructure/management-zone/zone"] = dynatraceEntity
 
 	managementZoneId, err := config.parseDependency("infrastructure/management-zone/zone.id", dict)
 	assert.NilError(t, err)

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -5,7 +5,6 @@ import (
 	"math/rand"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	"github.com/dynatrace-oss/dynatrace-monitoring-as-code/pkg/api"
 	"github.com/dynatrace-oss/dynatrace-monitoring-as-code/pkg/config"
@@ -130,10 +129,8 @@ func execute(environment environment.Environment, projects []project.Project, dr
 				return err
 			}
 
-			referenceId := strings.TrimPrefix(config.GetFullQualifiedId(), path+"/")
-
 			if entity.Name != "" {
-				dict[referenceId] = entity
+				dict[config.GetFullQualifiedId()] = entity
 			}
 		}
 	}

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -130,7 +130,7 @@ func execute(environment environment.Environment, projects []project.Project, dr
 			}
 
 			if entity.Name != "" {
-				dict[config.GetFullQualifiedId()] = entity
+				dict[configID] = entity
 			}
 		}
 	}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -54,9 +54,11 @@ func NewProject(fullQualifiedProjectFolderName string, projectFolderName string,
 
 	var configs = make([]config.Config, 0)
 
+	projectFolderPath := filepath.Join(projectRootFolder, fullQualifiedProjectFolderName)
+
 	// standardize projectRootFolder
 	// trim path separator from projectRoot
-	projectRootFolder = strings.Trim(projectRootFolder, string(os.PathSeparator))
+	projectRootFolder = filepath.Clean(projectRootFolder)
 
 	builder := projectBuilder{
 		projectRootFolder: projectRootFolder,
@@ -66,7 +68,7 @@ func NewProject(fullQualifiedProjectFolderName string, projectFolderName string,
 		configFactory:     config.NewConfigFactory(),
 		fileReader:        fileReader,
 	}
-	err := builder.readFolder(fullQualifiedProjectFolderName, true)
+	err := builder.readFolder(projectFolderPath, true)
 	if err != nil {
 		//debug log here?
 		return nil, err


### PR DESCRIPTION
In order to ease the handling of dependencies, references are now always
transformed to absolute paths. That way one can be sure that if he
encounters a cross reference, it is absolute.

Fixes #126