### PR TITLE
support for mobile applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ These are the supported configuration types, their API endpoints and the token p
 | anomaly-detection-metrics       | _/api/config/v1/anomalyDetection/metricEvents_  | `Read Configuration` & `Write Configuration`                                                                        |
 | app-detection-rule              | _/api/config/v1/applicationDetectionRules_      | `Read Configuration` & `Write Configuration`                                                                        |
 | application                     | _/api/config/v1/applications/web_               | `Read Configuration` & `Write Configuration`                                                                        |
+| application-mobile              | _/api/config/v1/applications/mobile_            | `Read Configuration` & `Write Configuration`
 | auto-tag                        | _/api/config/v1/autoTags_                       | `Read Configuration` & `Write Configuration`                                                                        |
 | aws-credentials                 | _/api/config/v1/aws/credentials_                | `Read Configuration` & `Write Configuration`                                                                        |
 | calculated-metrics-log          | _/api/config/v1/calculatedMetrics/log_          | `Read Configuration` & `Write Configuration`                                                                        |

--- a/README.md
+++ b/README.md
@@ -448,7 +448,8 @@ These are the supported configuration types, their API endpoints and the token p
 | alerting-profile                | _/api/config/v1/alertingProfiles_               | `Read Configuration` & `Write Configuration`                                                                        |
 | anomaly-detection-metrics       | _/api/config/v1/anomalyDetection/metricEvents_  | `Read Configuration` & `Write Configuration`                                                                        |
 | app-detection-rule              | _/api/config/v1/applicationDetectionRules_      | `Read Configuration` & `Write Configuration`                                                                        |
-| application                     | _/api/config/v1/applications/web_               | `Read Configuration` & `Write Configuration`                                                                        |
+| application **deprecated in 2.0.0!**| _/api/config/v1/applications/web_               | `Read Configuration` & `Write Configuration`                                                                        |
+| application-web **replaces application**| _/api/config/v1/applications/web_            | `Read Configuration` & `Write Configuration`
 | application-mobile              | _/api/config/v1/applications/mobile_            | `Read Configuration` & `Write Configuration`
 | auto-tag                        | _/api/config/v1/autoTags_                       | `Read Configuration` & `Write Configuration`                                                                        |
 | aws-credentials                 | _/api/config/v1/aws/credentials_                | `Read Configuration` & `Write Configuration`                                                                        |

--- a/cmd/monaco/test-resources/integration-all-configs/delete.yaml
+++ b/cmd/monaco/test-resources/integration-all-configs/delete.yaml
@@ -20,3 +20,4 @@ delete:
   - "maintenance-window/My First Maintenance Window"
   - "azure-credentials/Enterprise Azure Credentials"
   - "application-mobile/BORG Mobile Application"
+  - "application/BORG Web Application"

--- a/cmd/monaco/test-resources/integration-all-configs/delete.yaml
+++ b/cmd/monaco/test-resources/integration-all-configs/delete.yaml
@@ -19,3 +19,4 @@ delete:
   - "kubernetes-credentials/My Kubernetes Cluster"
   - "maintenance-window/My First Maintenance Window"
   - "azure-credentials/Enterprise Azure Credentials"
+  - "application-mobile/BORG Mobile Application"

--- a/cmd/monaco/test-resources/integration-all-configs/project/application-mobile/mobile-application.json
+++ b/cmd/monaco/test-resources/integration-all-configs/project/application-mobile/mobile-application.json
@@ -1,0 +1,13 @@
+{
+    "name": "{{ .name }}",
+    "applicationType": "MOBILE_APPLICATION",
+    "costControlUserSessionPercentage": 100,
+    "apdexSettings": {
+      "toleratedThreshold": 3000,
+      "frustratingThreshold": 12000,
+      "frustratedOnError": true
+    },
+    "optInModeEnabled": true,
+    "sessionReplayOnCrashEnabled": true,
+    "beaconEndpointType": "CLUSTER_ACTIVE_GATE"
+  }

--- a/cmd/monaco/test-resources/integration-all-configs/project/application-mobile/mobile-application.yaml
+++ b/cmd/monaco/test-resources/integration-all-configs/project/application-mobile/mobile-application.yaml
@@ -1,0 +1,6 @@
+
+config:
+  - mobile-application: "mobile-application.json"
+
+mobile-application:
+  - name: "BORG Mobile Application"

--- a/cmd/monaco/test-resources/integration-all-configs/project/application-web/application.json
+++ b/cmd/monaco/test-resources/integration-all-configs/project/application-web/application.json
@@ -1,0 +1,123 @@
+{
+  "name": "{{ .name }}",
+  "realUserMonitoringEnabled": true,
+  "costControlUserSessionPercentage": 100,
+  "loadActionKeyPerformanceMetric": "VISUALLY_COMPLETE",
+  "xhrActionKeyPerformanceMetric": "VISUALLY_COMPLETE",
+  "loadActionApdexSettings": {
+    "threshold": 1,
+    "toleratedThreshold": 1000,
+    "frustratingThreshold": 3000,
+    "toleratedFallbackThreshold": 1300,
+    "frustratingFallbackThreshold": 3300,
+    "considerJavaScriptErrors": true
+  },
+  "xhrActionApdexSettings": {
+    "threshold": 3,
+    "toleratedThreshold": 3000,
+    "frustratingThreshold": 12000,
+    "toleratedFallbackThreshold": 3000,
+    "frustratingFallbackThreshold": 12000,
+    "considerJavaScriptErrors": true
+  },
+  "customActionApdexSettings": {
+    "threshold": 3,
+    "toleratedThreshold": 3000,
+    "frustratingThreshold": 12000,
+    "toleratedFallbackThreshold": 3000,
+    "frustratingFallbackThreshold": 12000,
+    "considerJavaScriptErrors": true
+  },
+  "waterfallSettings": {
+    "uncompressedResourcesThreshold": 860,
+    "resourcesThreshold": 100000,
+    "resourceBrowserCachingThreshold": 50,
+    "slowFirstPartyResourcesThreshold": 200000,
+    "slowThirdPartyResourcesThreshold": 200000,
+    "slowCdnResourcesThreshold": 200000,
+    "speedIndexVisuallyCompleteRatioThreshold": 50
+  },
+  "monitoringSettings": {
+    "fetchRequests": true,
+    "xmlHttpRequest": true,
+    "javaScriptFrameworkSupport": {
+      "angular": true,
+      "dojo": false,
+      "extJS": false,
+      "icefaces": false,
+      "jQuery": false,
+      "mooTools": false,
+      "prototype": false,
+      "activeXObject": false
+    },
+    "contentCapture": {
+      "resourceTimingSettings": {
+        "w3cResourceTimings": true,
+        "nonW3cResourceTimings": false,
+        "nonW3cResourceTimingsInstrumentationDelay": 50,
+        "resourceTimingCaptureType": "CAPTURE_FULL_DETAILS",
+        "resourceTimingsDomainLimit": 10
+      },
+      "javaScriptErrors": true,
+      "timeoutSettings": {
+        "timedActionSupport": false,
+        "temporaryActionLimit": 0,
+        "temporaryActionTotalTimeout": 100
+      },
+      "visuallyCompleteAndSpeedIndex": true
+    },
+    "excludeXhrRegex": "",
+    "injectionMode": "JAVASCRIPT_TAG",
+    "libraryFileLocation": "",
+    "monitoringDataPath": "",
+    "customConfigurationProperties": "",
+    "serverRequestPathId": "",
+    "secureCookieAttribute": false,
+    "cookiePlacementDomain": "",
+    "cacheControlHeaderOptimizations": true,
+    "advancedJavaScriptTagSettings": {
+      "syncBeaconFirefox": false,
+      "syncBeaconInternetExplorer": false,
+      "instrumentUnsupportedAjaxFrameworks": false,
+      "specialCharactersToEscape": "",
+      "maxActionNameLength": 100,
+      "maxErrorsToCapture": 10,
+      "additionalEventHandlers": {
+        "userMouseupEventForClicks": false,
+        "clickEventHandler": false,
+        "mouseupEventHandler": false,
+        "blurEventHandler": false,
+        "changeEventHandler": false,
+        "toStringMethod": false,
+        "maxDomNodesToInstrument": 5000
+      },
+      "eventWrapperSettings": {
+        "click": false,
+        "mouseUp": false,
+        "change": false,
+        "blur": false,
+        "touchStart": false,
+        "touchEnd": false
+      },
+      "globalEventCaptureSettings": {
+        "mouseUp": true,
+        "mouseDown": true,
+        "click": true,
+        "doubleClick": true,
+        "keyUp": true,
+        "keyDown": true,
+        "scroll": true,
+        "additionalEventCapturedAsUserInput": ""
+      }
+    }
+  },
+  "userActionNamingSettings": {
+    "placeholders": [],
+    "loadActionNamingRules": [],
+    "xhrActionNamingRules": [],
+    "ignoreCase": true,
+    "splitUserActionsByDomain": true
+  },
+  "metaDataCaptureSettings": [],
+  "conversionGoals": []
+}

--- a/cmd/monaco/test-resources/integration-all-configs/project/application-web/application.yaml
+++ b/cmd/monaco/test-resources/integration-all-configs/project/application-web/application.yaml
@@ -1,0 +1,6 @@
+
+config:
+  - application: "application.json"
+
+application:
+  - name: "BORG Web Application"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -41,6 +41,7 @@ var apiMap = map[string]string{
 	// Environment API not Config API
 	"synthetic-monitor":  "/api/v1/synthetic/monitors",
 	"application":        "/api/config/v1/applications/web",
+	"application-mobile": "/api/config/v1/applications/mobile",
 	"app-detection-rule": "/api/config/v1/applicationDetectionRules",
 	"aws-credentials":    "/api/config/v1/aws/credentials",
 	// Early adopter API !

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -39,8 +39,10 @@ var apiMap = map[string]string{
 	"synthetic-location": "/api/v1/synthetic/locations",
 	// Early adopter API !
 	// Environment API not Config API
-	"synthetic-monitor":  "/api/v1/synthetic/monitors",
+	"synthetic-monitor": "/api/v1/synthetic/monitors",
+	// To be deprecated in v2.0.0, replaced by application-web
 	"application":        "/api/config/v1/applications/web",
+	"application-web":    "/api/config/v1/applications/web",
 	"application-mobile": "/api/config/v1/applications/mobile",
 	"app-detection-rule": "/api/config/v1/applicationDetectionRules",
 	"aws-credentials":    "/api/config/v1/aws/credentials",

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -155,6 +155,12 @@ func (p *projectBuilder) processConfigSection(properties map[string]map[string]s
 
 		location = p.standardizeLocation(location, folderPath)
 
+		//Introduce deprecation warning message when using the config type "application"
+		util.Log.Debug("Config type: " + getConfigType(folderPath))
+		if getConfigType(folderPath) == "application" {
+			util.Log.Warn("You are using the configuration 'application', which will be deprecated in v2.0.0. Replace with type 'application-web'.")
+		}
+
 		err, api := p.getExtendedInformationFromLocation(location)
 		if util.CheckError(err, "Could not find API fom location") {
 			return err
@@ -278,4 +284,10 @@ func (p *projectImpl) HasDependencyOn(project Project) bool {
 		}
 	}
 	return false
+}
+
+func getConfigType(folderPath string) string {
+
+	lastSlashLocation := strings.LastIndex(folderPath, "/")
+	return folderPath[lastSlashLocation+1 : len(folderPath)]
 }

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -155,15 +155,14 @@ func (p *projectBuilder) processConfigSection(properties map[string]map[string]s
 
 		location = p.standardizeLocation(location, folderPath)
 
-		//Introduce deprecation warning message when using the config type "application"
-		util.Log.Debug("Config type: " + getConfigType(folderPath))
-		if getConfigType(folderPath) == "application" {
-			util.Log.Warn("You are using the configuration 'application', which will be deprecated in v2.0.0. Replace with type 'application-web'.")
-		}
-
 		err, api := p.getExtendedInformationFromLocation(location)
 		if util.CheckError(err, "Could not find API fom location") {
 			return err
+		}
+
+		//Introduce deprecation warning message when using the config type "application"
+		if api.GetId() == "application" {
+			util.Log.Warn("You are using the configuration 'application', which will be deprecated in v2.0.0. Replace with type 'application-web'.")
 		}
 
 		config, err := p.configFactory.NewConfig(configName, p.projectId, location, properties, api)
@@ -284,10 +283,4 @@ func (p *projectImpl) HasDependencyOn(project Project) bool {
 		}
 	}
 	return false
-}
-
-func getConfigType(folderPath string) string {
-
-	lastSlashLocation := strings.LastIndex(folderPath, "/")
-	return folderPath[lastSlashLocation+1 : len(folderPath)]
 }


### PR DESCRIPTION
Added support for the `applications/mobile` endpoint.
- Added endpoint definition in api.go
- Added test files in `integration-all-configs` project

Added a config type for the `applications/web`endpoint
- This already existed before as `application`, but now it is also there as `application-web`
- Added a warning message that with v2.0.0 the `application` config type will be deprecated if it is being used

For issue https://github.com/dynatrace-oss/dynatrace-monitoring-as-code/issues/146 