### PR TITLE
Add editorconfig to standardize various style related things

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+tab_width = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.go]
+indent_style = tab
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.yaml]
+indent_size = 2
+tab_width = 2
+
+[*.md]
+max_line_length = off
+# Trailing whitespaces are needed in markdown for line breaks
+trim_trailing_whitespace = false


### PR DESCRIPTION
After editing the README I noticed, that we have some style differences
in there. Hence a .editorconfig file was created to have a standard set
of formating rules such as tabs vs spaces, tab width across all
contributors.