### PR TITLE
Fix verbose flag not working in new cli

### DIFF
--- a/cmd/monaco/main.go
+++ b/cmd/monaco/main.go
@@ -114,7 +114,7 @@ Examples:
 		},
 		&cli.PathFlag{
 			Name:      "environments",
-			Usage:     "Yaml file containing environment to deploye to",
+			Usage:     "Yaml file containing environments to deploy to",
 			Aliases:   []string{"e"},
 			Required:  true,
 			TakesFile: true,
@@ -209,7 +209,7 @@ Examples:
 func getDeployCommand(fileReader util.FileReader) cli.Command {
 	command := cli.Command{
 		Name:      "deploy",
-		Usage:     "deployes the given environment",
+		Usage:     "deploys the given environment",
 		UsageText: "deploy [command options] [working directory]",
 		ArgsUsage: "[working directory]",
 		Before: func(c *cli.Context) error {

--- a/cmd/monaco/main.go
+++ b/cmd/monaco/main.go
@@ -159,7 +159,6 @@ Examples:
 			ctx.String("specific-environment"),
 			ctx.String("project"),
 			ctx.Bool("dry-run"),
-			ctx.Bool("verbose"),
 		)
 	}
 
@@ -201,18 +200,6 @@ Examples:
   Deploy a specific project to a specific tenant:
     monaco deploy --environments environments.yaml --specific-environment dev --project myProject
 `
-	app.Before = func(c *cli.Context) error {
-		err := util.SetupLogging(c.Bool("verbose"))
-
-		if err != nil {
-			return err
-		}
-
-		util.Log.Info("Dynatrace Monitoring as Code v" + version.MonitoringAsCode)
-
-		return nil
-	}
-
 	deployCommand := getDeployCommand(fileReader)
 	downloadCommand := getDownloadCommand(fileReader)
 	app.Commands = []*cli.Command{&deployCommand, &downloadCommand}
@@ -225,6 +212,17 @@ func getDeployCommand(fileReader util.FileReader) cli.Command {
 		Usage:     "deployes the given environment",
 		UsageText: "deploy [command options] [working directory]",
 		ArgsUsage: "[working directory]",
+		Before: func(c *cli.Context) error {
+			err := util.SetupLogging(c.Bool("verbose"))
+
+			if err != nil {
+				return err
+			}
+
+			util.Log.Info("Dynatrace Monitoring as Code v" + version.MonitoringAsCode)
+
+			return nil
+		},
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:    "verbose",
@@ -274,7 +272,6 @@ func getDeployCommand(fileReader util.FileReader) cli.Command {
 				ctx.String("specific-environment"),
 				ctx.String("project"),
 				ctx.Bool("dry-run"),
-				ctx.Bool("verbose"),
 			)
 		},
 	}
@@ -285,6 +282,17 @@ func getDownloadCommand(fileReader util.FileReader) cli.Command {
 		Name:      "download",
 		Usage:     "download the given environment",
 		UsageText: "download [command options] [working directory]",
+		Before: func(c *cli.Context) error {
+			err := util.SetupLogging(c.Bool("verbose"))
+
+			if err != nil {
+				return err
+			}
+
+			util.Log.Info("Dynatrace Monitoring as Code v" + version.MonitoringAsCode)
+
+			return nil
+		},
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:    "verbose",
@@ -323,7 +331,6 @@ func getDownloadCommand(fileReader util.FileReader) cli.Command {
 				ctx.Path("environments"),
 				ctx.String("specific-environment"),
 				ctx.String("downloadSpecificAPI"),
-				ctx.Bool("verbose"),
 			)
 		},
 	}

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -17,7 +17,7 @@ import (
 )
 
 func Deploy(workingDir string, fileReader util.FileReader, environmentsFile string,
-	specificEnvironment string, proj string, dryRun bool, verbose bool) error {
+	specificEnvironment string, proj string, dryRun bool) error {
 	environments, errors := environment.LoadEnvironmentList(specificEnvironment, environmentsFile, fileReader)
 
 	workingDir = filepath.Clean(workingDir)

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -18,7 +18,7 @@ var cont = 0
 
 //GetConfigsFilterByEnvironment filters the enviroments list based on specificEnvironment flag value
 func GetConfigsFilterByEnvironment(workingDir string, fileReader util.FileReader, environmentsFile string,
-	specificEnvironment string, downloadSpecificAPI string, verbose bool) error {
+	specificEnvironment string, downloadSpecificAPI string) error {
 	environments, errors := environment.LoadEnvironmentList(specificEnvironment, environmentsFile, fileReader)
 	if len(errors) > 0 {
 		for _, err := range errors {


### PR DESCRIPTION
Due to a misunderstanding how the cli parsing library works, the verbose
flag was never set correctly in the new cli. This has now been fixed.