### PR TITLE
Cope with faulty configs (name or id is null)

### DIFF
--- a/pkg/rest/config_upload.go
+++ b/pkg/rest/config_upload.go
@@ -286,7 +286,7 @@ func translateGenericValues(inputValues []interface{}, configType string) ([]api
 				continue
 			}
 
-			util.Log.Warn("Config of type %s was invalid: %s", configType, string(jsonStr))
+			util.Log.Warn("Config of type %s was invalid. Auto-corrected to use ID as name!\nInvalid config: %s", configType, string(jsonStr))
 
 			values[i] = api.Value{
 				Id:   input["id"].(string),

--- a/pkg/rest/config_upload.go
+++ b/pkg/rest/config_upload.go
@@ -282,7 +282,7 @@ func translateGenericValues(inputValues []interface{}, configType string) ([]api
 		if input["name"] == nil {
 			jsonStr, err := json.Marshal(input)
 			if err != nil {
-				util.Log.Warn("Could not marshal %s", configType)
+				util.Log.Warn("Config of type %s was invalid. Ignoring it!", configType)
 				continue
 			}
 

--- a/pkg/rest/config_upload_test.go
+++ b/pkg/rest/config_upload_test.go
@@ -1,0 +1,72 @@
+// +build unit
+
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rest
+
+import (
+	"gotest.tools/assert"
+	"testing"
+)
+
+func TestTranslateGenericValuesOnStandardResponse(t *testing.T) {
+
+	entry := make(map[string]interface{})
+	entry["id"] = "foo"
+	entry["name"] = "bar"
+
+	response := make([]interface{}, 1)
+	response[0] = entry
+
+	values, err := translateGenericValues(response, "extensions")
+
+	assert.NilError(t, err)
+	assert.Check(t, len(values) == 1)
+
+	assert.Equal(t, values[0].Id, "foo")
+	assert.Equal(t, values[0].Name, "bar")
+}
+
+func TestTranslateGenericValuesOnIdMissing(t *testing.T) {
+
+	entry := make(map[string]interface{})
+	entry["name"] = "bar"
+
+	response := make([]interface{}, 1)
+	response[0] = entry
+
+	_, err := translateGenericValues(response, "extensions")
+
+	assert.ErrorContains(t, err, "config of type extensions was invalid: No id")
+}
+
+func TestTranslateGenericValuesOnNameMissing(t *testing.T) {
+
+	entry := make(map[string]interface{})
+	entry["id"] = "foo"
+
+	response := make([]interface{}, 1)
+	response[0] = entry
+
+	values, err := translateGenericValues(response, "extensions")
+
+	assert.NilError(t, err)
+	assert.Check(t, len(values) == 1)
+
+	assert.Equal(t, values[0].Id, "foo")
+	assert.Equal(t, values[0].Name, "foo")
+}


### PR DESCRIPTION
It can happen that you have a faulty config deployed in your
environment, which has no id or name set. These special cases were not
handled correctly before. Instead, `monaco` crashed when getting the
list of configs. This commit introduces a graceful handling of these
configs in monaco.

If the id is null -> Return an error
If the name is null -> Fill in the id as the name (as done by the
extensions API)