### PR TITLE
Release version 1.3.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,26 +1,10 @@
 # Monitoring as Code Tool - Release Notes
 
-- [Monitoring as Code Tool - Release Notes](#monitoring-as-code-tool---release-notes)
+- Versions:
   - [1.3.1](#131)
-    - [List of changes](#list-of-changes)
-      - [Bugfixes](#bugfixes)
   - [1.3.0](#130)
-    - [List of changes](#list-of-changes-1)
-      - [Deprecation Warnings](#deprecation-warnings)
-      - [Features](#features)
-      - [Bugfixes](#bugfixes-1)
-      - [Misc changes](#misc-changes)
   - [1.2.0](#120)
-    - [List of changes](#list-of-changes-2)
-      - [Features](#features-1)
-      - [Bugfixes](#bugfixes-2)
-      - [Misc changes](#misc-changes-1)
   - [1.1.0](#110)
-    - [List of changes](#list-of-changes-3)
-      - [Features](#features-2)
-      - [Bugfixes](#bugfixes-3)
-      - [Library updates](#library-updates)
-      - [Misc changes](#misc-changes-2)
   - [1.0.1](#101)
   - [1.0.0](#100)
 
@@ -36,13 +20,13 @@
 ### List of changes
 
 #### Deprecation Warnings
-* #146: `application-web` configuration type replaces `application` in the future
-  * `application` config type is deprecated with 1.3.0 and will be removed with 2.0.0
+  * Fix #146: `application-web` configuration type replaces `application` in the future (#149)
+  * `application` config type is deprecated with 1.3.0 and will be removed with 2.0.0 (#149)
 
 #### Features
 
-* #146: Add support for `application-mobile`(applications/mobile) configurations
-* #66: Add support for `slo` (/api/v2/slo) configruations
+  * Fix #146: Add support for `application-mobile`(applications/mobile) configurations (#149)
+  * 5558b61 Fix #66: Add support for `slo` (/api/v2/slo) configruations (#153)
 
 #### Bugfixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,25 +1,35 @@
 # Monitoring as Code Tool - Release Notes
 
 - [Monitoring as Code Tool - Release Notes](#monitoring-as-code-tool---release-notes)
-  - [1.3.0](#130)
+  - [1.3.1](#131)
     - [List of changes](#list-of-changes)
+      - [Bugfixes](#bugfixes)
+  - [1.3.0](#130)
+    - [List of changes](#list-of-changes-1)
       - [Deprecation Warnings](#deprecation-warnings)
       - [Features](#features)
-      - [Bugfixes](#bugfixes)
+      - [Bugfixes](#bugfixes-1)
       - [Misc changes](#misc-changes)
   - [1.2.0](#120)
-    - [List of changes](#list-of-changes-1)
+    - [List of changes](#list-of-changes-2)
       - [Features](#features-1)
-      - [Bugfixes](#bugfixes-1)
+      - [Bugfixes](#bugfixes-2)
       - [Misc changes](#misc-changes-1)
   - [1.1.0](#110)
-    - [List of changes](#list-of-changes-2)
+    - [List of changes](#list-of-changes-3)
       - [Features](#features-2)
-      - [Bugfixes](#bugfixes-2)
+      - [Bugfixes](#bugfixes-3)
       - [Library updates](#library-updates)
       - [Misc changes](#misc-changes-2)
   - [1.0.1](#101)
   - [1.0.0](#100)
+
+## 1.3.1
+
+### List of changes
+#### Bugfixes
+
+* 2e0e88a: Cope with faulty configs (name or id is null) (#169)
 
 ## 1.3.0
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,4 +16,4 @@
 
 package version
 
-const MonitoringAsCode = "1.3.0"
+const MonitoringAsCode = "1.3.1"


### PR DESCRIPTION
This commit extends the documentation for monaco version 1.3.1 and
sets its version. monaco 1.3.1 contains the following changes:

Bugfixes:
  * 2e0e88a: Cope with faulty configs (name or id is null) (#169)