### PR TITLE
support for custom-service dotnet,go,nodejs,php

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ and [Configuration Structure](#configuration-structure)
       - [Experimental new CLI](#experimental-new-cli)
         - [Deploy](#deploy)
         - [Download](#download)
-      - [Misc](#cli-misc)
-        - [Logging all requests send to dynatrace](#cli-misc-log-requests)
+      - [Misc](#misc)
+        - [Logging all requests send to dynatrace](#logging-all-requests-send-to-dynatrace)
     - [Deploying Configuration to Dynatrace](#deploying-configuration-to-dynatrace)
       - [Running The Tool](#running-the-tool)
       - [Environments file](#environments-file)
@@ -459,6 +459,10 @@ These are the supported configuration types, their API endpoints and the token p
 | conditional-naming-processgroup | _/api/config/v1/conditionalNaming/processGroup_ | `Read Configuration` & `Write Configuration`                                                                        |
 | conditional-naming-service      | _/api/config/v1/conditionalNaming/service_      | `Read Configuration` & `Write Configuration`                                                                        |
 | custom-service-java             | _/api/config/v1/service/customServices/java_    | `Read Configuration` & `Write Configuration`                                                                        |
+| custom-service-dotnet           | _/api/config/v1/service/customServices/dotnet_  | `Read Configuration` & `Write Configuration`                                                                        |
+| custom-service-go               | _/api/config/v1/service/customServices/go_      | `Read Configuration` & `Write Configuration`                                                                        |
+| custom-service-nodejs           | _/api/config/v1/service/customServices/nodejs_  | `Read Configuration` & `Write Configuration`                                                                        |
+| custom-service-php              | _/api/config/v1/service/customServices/php_     | `Read Configuration` & `Write Configuration`                                                                        |
 | dashboard                       | _/api/config/v1/dashboards_                     | `Read Configuration` & `Write Configuration`                                                                        |
 | extension                       | _/api/config/v1/extensions_                     | `Read Configuration` & `Write Configuration`                                                                        |
 | maintenance-window              | _/api/config/v1/maintenanceWindows_             | `Deprecated: Configure maintenance windows`                                                                         |

--- a/cmd/monaco/test-resources/integration-all-configs/delete.yaml
+++ b/cmd/monaco/test-resources/integration-all-configs/delete.yaml
@@ -21,3 +21,7 @@ delete:
   - "azure-credentials/Enterprise Azure Credentials"
   - "application-mobile/BORG Mobile Application"
   - "application/BORG Web Application"
+  - "custom-service-java/Enterprise Warp Drive dotNet"
+  - "custom-service-java/Enterprise Warp Drive GoLang"
+  - "custom-service-java/Enterprise Warp Drive NodeJS"
+  - "custom-service-java/Enterprise Warp Drive php"

--- a/cmd/monaco/test-resources/integration-all-configs/project/custom-service-dotnet/warp-drive-service.json
+++ b/cmd/monaco/test-resources/integration-all-configs/project/custom-service-dotnet/warp-drive-service.json
@@ -1,0 +1,22 @@
+{
+    "name": "{{ .name }}",
+    "enabled": true,
+    "rules": [
+      {
+        "enabled": true,
+        "fileName": "",
+        "className": "com.dynatrace.easytravel.servicex",
+        "matcher": "EQUALS",
+        "methodRules": [
+          {
+            "methodName": "methody",
+            "returnType": "void"
+          }
+        ],
+        "annotations": []
+      }
+    ],
+    "queueEntryPoint": false,
+    "queueEntryPointType": null,
+    "processGroups": []
+  }

--- a/cmd/monaco/test-resources/integration-all-configs/project/custom-service-dotnet/warp-drive-services.yaml
+++ b/cmd/monaco/test-resources/integration-all-configs/project/custom-service-dotnet/warp-drive-services.yaml
@@ -1,0 +1,6 @@
+
+config:
+  - warp-drive-service: "warp-drive-service.json"
+
+warp-drive-service:
+  - name: "Enterprise Warp Drive dotNet"

--- a/cmd/monaco/test-resources/integration-all-configs/project/custom-service-go/warp-drive-service.json
+++ b/cmd/monaco/test-resources/integration-all-configs/project/custom-service-go/warp-drive-service.json
@@ -1,0 +1,20 @@
+{
+    "name": "{{ .name }}",
+    "enabled": true,
+    "rules": [
+        {
+        "enabled": true,
+        "className": "AClass",
+        "methodRules": [
+            {
+            "methodName": "AMethod",
+            "argumentTypes": [
+                "java.lang.String"
+            ],
+            "returnType": "void"
+            }
+        ]
+        }
+    ],
+    "queueEntryPoint": false
+}

--- a/cmd/monaco/test-resources/integration-all-configs/project/custom-service-go/warp-drive-services.yaml
+++ b/cmd/monaco/test-resources/integration-all-configs/project/custom-service-go/warp-drive-services.yaml
@@ -1,0 +1,6 @@
+
+config:
+  - warp-drive-service: "warp-drive-service.json"
+
+warp-drive-service:
+  - name: "Enterprise Warp Drive GoLang"

--- a/cmd/monaco/test-resources/integration-all-configs/project/custom-service-nodejs/warp-drive-service.json
+++ b/cmd/monaco/test-resources/integration-all-configs/project/custom-service-nodejs/warp-drive-service.json
@@ -1,0 +1,20 @@
+{
+    "name": "{{ .name }}",
+    "enabled": true,
+    "rules": [
+      {
+        "enabled": true,
+        "fileName": "AFile.js",
+        "methodRules": [
+          {
+            "methodName": "AMethod",
+            "argumentTypes": [
+              "java.lang.String"
+            ],
+            "returnType": "void"
+          }
+        ]
+      }
+    ],
+    "queueEntryPoint": false
+  }

--- a/cmd/monaco/test-resources/integration-all-configs/project/custom-service-nodejs/warp-drive-services.yaml
+++ b/cmd/monaco/test-resources/integration-all-configs/project/custom-service-nodejs/warp-drive-services.yaml
@@ -1,0 +1,6 @@
+
+config:
+  - warp-drive-service: "warp-drive-service.json"
+
+warp-drive-service:
+  - name: "Enterprise Warp Drive NodeJS"

--- a/cmd/monaco/test-resources/integration-all-configs/project/custom-service-php/warp-drive-service.json
+++ b/cmd/monaco/test-resources/integration-all-configs/project/custom-service-php/warp-drive-service.json
@@ -1,0 +1,23 @@
+{
+    "name": "{{ .name }}",
+    "enabled": true,
+    "rules": [
+      {
+        "enabled": true,
+        "fileName": "phpFile",
+        "fileNameMatcher": "ENDS_WITH",
+        "className": "",
+        "matcher": "EQUALS",
+        "methodRules": [
+          {
+            "methodName": "myMethod",
+            "returnType": "void"
+          }
+        ],
+        "annotations": []
+      }
+    ],
+    "queueEntryPoint": false,
+    "queueEntryPointType": null,
+    "processGroups": []
+  }

--- a/cmd/monaco/test-resources/integration-all-configs/project/custom-service-php/warp-drive-services.yaml
+++ b/cmd/monaco/test-resources/integration-all-configs/project/custom-service-php/warp-drive-services.yaml
@@ -1,0 +1,6 @@
+
+config:
+  - warp-drive-service: "warp-drive-service.json"
+
+warp-drive-service:
+  - name: "Enterprise Warp Drive PHP"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -51,6 +51,18 @@ var apiMap = map[string]apiInput{
 	"custom-service-java": {
 		apiPath: "/api/config/v1/service/customServices/java",
 	},
+	"custom-service-dotnet": {
+		apiPath: "/api/config/v1/service/customServices/dotNet",
+	},
+	"custom-service-go": {
+		apiPath: "/api/config/v1/service/customServices/go",
+	},
+	"custom-service-nodejs": {
+		apiPath: "/api/config/v1/service/customServices/nodeJS",
+	},
+	"custom-service-php": {
+		apiPath: "/api/config/v1/service/customServices/php",
+	},
 	// Early adopter API !
 	"anomaly-detection-metrics": {
 		apiPath: "/api/config/v1/anomalyDetection/metricEvents",


### PR DESCRIPTION
- added config types for custom-service-dotnet, custom-service-go, custom-service-nodejs, custom-service-php.
- added documentation in Readme.md
- added test files in integration-all-configs

In support of https://github.com/dynatrace-oss/dynatrace-monitoring-as-code/issues/158