### PR TITLE
Log error on request log error

### DIFF
--- a/pkg/rest/request.go
+++ b/pkg/rest/request.go
@@ -77,7 +77,11 @@ func executeRequest(client *http.Client, request *http.Request) Response {
 	var requestId string
 	if util.IsRequestLoggingActive() {
 		requestId = uuid.NewString()
-		util.LogRequest(requestId, request)
+		err := util.LogRequest(requestId, request)
+
+		if err != nil {
+			util.Log.Warn("error while writing request log for id `%s`: %v", requestId, err)
+		}
 	}
 
 	rateLimitStrategy := createRateLimitStrategy()
@@ -94,7 +98,15 @@ func executeRequest(client *http.Client, request *http.Request) Response {
 		body, err := ioutil.ReadAll(resp.Body)
 
 		if util.IsResponseLoggingActive() {
-			util.LogResponse(requestId, resp)
+			err := util.LogResponse(requestId, resp)
+
+			if err != nil {
+				if requestId != "" {
+					util.Log.Warn("error while writing response log for id `%s`: %v", requestId, err)
+				} else {
+					util.Log.Warn("error while writing response log: %v", requestId, err)
+				}
+			}
 		}
 
 		return Response{

--- a/pkg/util/logging.go
+++ b/pkg/util/logging.go
@@ -148,9 +148,16 @@ func LogRequest(id string, request *http.Request) error {
 		return err
 	}
 
-	requestLogFile.WriteString(fmt.Sprintf("Request-ID: %s\n", id))
-	requestLogFile.Write(dump)
-	requestLogFile.WriteString("\n=========================\n")
+	stringDump := string(dump)
+
+	_, err = requestLogFile.WriteString(fmt.Sprintf(`Request-ID: %s
+%s
+=========================
+`, id, stringDump))
+
+	if err != nil {
+		return err
+	}
 
 	return requestLogFile.Sync()
 }
@@ -175,11 +182,22 @@ func LogResponse(id string, response *http.Response) error {
 	}
 
 	if id != "" {
-		responseLogFile.WriteString(fmt.Sprintf("Request-ID: %s\n", id))
+		_, err = responseLogFile.WriteString(fmt.Sprintf("Request-ID: %s\n", id))
+
+		if err != nil {
+			return err
+		}
 	}
 
-	responseLogFile.Write(dump)
-	responseLogFile.WriteString("\n=========================\n")
+	stringDump := string(dump)
+
+	_, err = responseLogFile.WriteString(fmt.Sprintf(`%s
+=========================
+`, stringDump))
+
+	if err != nil {
+		return err
+	}
 
 	return responseLogFile.Sync()
 }


### PR DESCRIPTION
If for whatever reason there is an error while logging the
request/response, the user now sees this in the monaco log output as a
warning message.