### PR TITLE
Fix template loading for abosolute template reference

### DIFF
--- a/pkg/util/template.go
+++ b/pkg/util/template.go
@@ -19,6 +19,7 @@ package util
 import (
 	"bytes"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -50,8 +51,9 @@ func NewTemplateFromString(name string, content string) (Template, error) {
 
 // NewTemplate creates a new template for the given file
 func NewTemplate(fs afero.IOFS, fileName string) (Template, error) {
+	cleanedFilename := filepath.Clean(fileName)
 
-	templ, err := template.ParseFS(fs, fileName)
+	templ, err := template.ParseFS(fs, cleanedFilename)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
It seems like that golangs `template.ParseFS` needs to be cleaned,
otherwise it fails.