### PR TITLE
Fix absolute paths broken

### DIFF
--- a/cmd/monaco/all_configs_integration_test.go
+++ b/cmd/monaco/all_configs_integration_test.go
@@ -31,7 +31,7 @@ func TestIntegrationAllConfigs(t *testing.T) {
 	allConfigsFolder := "test-resources/integration-all-configs/"
 	allConfigsEnvironmentsFile := allConfigsFolder + "environments.yaml"
 
-	RunIntegrationWithCleanup(t, allConfigsFolder, allConfigsEnvironmentsFile, "AllConfigs", func(fs afero.IOFS) {
+	RunIntegrationWithCleanup(t, allConfigsFolder, allConfigsEnvironmentsFile, "AllConfigs", func(fs afero.Fs) {
 
 		statusCode := RunImpl([]string{
 			"monaco",

--- a/cmd/monaco/config_restore_e2e_test.go
+++ b/cmd/monaco/config_restore_e2e_test.go
@@ -81,7 +81,7 @@ func testRestoreConfigs(t *testing.T, initialConfigsFolder string, downloadFolde
 	os.Setenv("NEW_CLI", "0")
 }
 
-func preparation_uploadConfigs(t *testing.T, fs afero.IOFS, suffixTest string, configFolder string, envFile string) error {
+func preparation_uploadConfigs(t *testing.T, fs afero.Fs, suffixTest string, configFolder string, envFile string) error {
 	util.Log.Info("BEGIN PREPARATION PROCESS")
 	suffix := getTimestamp() + suffixTest
 	transformers := []func(string) string{getTransformerFunc(suffix)}
@@ -99,7 +99,7 @@ func preparation_uploadConfigs(t *testing.T, fs afero.IOFS, suffixTest string, c
 	assert.Equal(t, statusCode, 0)
 	return nil
 }
-func execution_downloadConfigs(t *testing.T, fs afero.IOFS, downloadFolder string, envFile string,
+func execution_downloadConfigs(t *testing.T, fs afero.Fs, downloadFolder string, envFile string,
 	apisToDownload string, suffixTest string) error {
 	util.Log.Info("BEGIN DOWNLOAD PROCESS")
 	//Download
@@ -128,11 +128,11 @@ func execution_downloadConfigs(t *testing.T, fs afero.IOFS, downloadFolder strin
 
 	return nil
 }
-func validation_uploadDownloadedConfigs(t *testing.T, fs afero.IOFS, downloadFolder string,
+func validation_uploadDownloadedConfigs(t *testing.T, fs afero.Fs, downloadFolder string,
 	envFile string) {
 	util.Log.Info("BEGIN VALIDATION PROCESS")
 	//Shows you the downloaded files list in the command line
-	_ = afero.Walk(fs.Fs, downloadFolder+"/", func(path string, info os.FileInfo, err error) error {
+	_ = afero.Walk(fs, downloadFolder+"/", func(path string, info os.FileInfo, err error) error {
 		fpath, err := filepath.Abs(path)
 		util.Log.Info("file " + fpath)
 		return nil
@@ -147,7 +147,7 @@ func validation_uploadDownloadedConfigs(t *testing.T, fs afero.IOFS, downloadFol
 }
 
 // Deletes all configs that end with "_suffix", where suffix == suffixTest+suffixTimestamp
-func cleanupEnvironmentConfigs(t *testing.T, fs afero.IOFS, envFile, suffix string) {
+func cleanupEnvironmentConfigs(t *testing.T, fs afero.Fs, envFile, suffix string) {
 	util.Log.Info("BEGIN CLEANUP PROCESS")
 	environments, errs := environment.LoadEnvironmentList("", envFile, fs)
 	FailOnAnyError(errs, "loading of environments failed")

--- a/cmd/monaco/continue_deployment_on_error_integration_test.go
+++ b/cmd/monaco/continue_deployment_on_error_integration_test.go
@@ -35,7 +35,7 @@ func TestIntegrationContinueDeploymentOnError(t *testing.T) {
 	const allConfigsFolder = "test-resources/integration-configs-with-errors/"
 	const allConfigsEnvironmentsFile = allConfigsFolder + "environments.yaml"
 
-	RunIntegrationWithCleanup(t, allConfigsFolder, allConfigsEnvironmentsFile, "AllConfigs", func(fs afero.IOFS) {
+	RunIntegrationWithCleanup(t, allConfigsFolder, allConfigsEnvironmentsFile, "AllConfigs", func(fs afero.Fs) {
 
 		environments, errs := environment.LoadEnvironmentList("", allConfigsEnvironmentsFile, fs)
 		assert.Check(t, len(errs) == 0, "didn't expect errors loading test environments")

--- a/cmd/monaco/integration_test_utils.go
+++ b/cmd/monaco/integration_test_utils.go
@@ -120,7 +120,7 @@ func getTransformerFunc(suffix string) func(line string) string {
 }
 
 // Deletes all configs that end with "_suffix", where suffix == suffixTest+suffixTimestamp
-func cleanupIntegrationTest(t *testing.T, fs afero.IOFS, envFile, suffix string) {
+func cleanupIntegrationTest(t *testing.T, fs afero.Fs, envFile, suffix string) {
 
 	environments, errs := environment.LoadEnvironmentList("", envFile, fs)
 	FailOnAnyError(errs, "loading of environments failed")
@@ -166,7 +166,7 @@ func cleanupIntegrationTest(t *testing.T, fs afero.IOFS, envFile, suffix string)
 // <original name>_<current timestamp><defined suffix>
 // e.g. my-config_1605258980000_Suffix
 
-func RunIntegrationWithCleanup(t *testing.T, configFolder, envFile, suffixTest string, testFunc func(fs afero.IOFS)) {
+func RunIntegrationWithCleanup(t *testing.T, configFolder, envFile, suffixTest string, testFunc func(fs afero.Fs)) {
 
 	suffix := getTimestamp() + suffixTest
 	transformers := []func(string) string{getTransformerFunc(suffix)}

--- a/cmd/monaco/main.go
+++ b/cmd/monaco/main.go
@@ -34,11 +34,10 @@ func main() {
 }
 
 func Run(args []string) int {
-	fsStdlib := afero.NewIOFS(afero.NewOsFs())
-	return RunImpl(args, fsStdlib)
+	return RunImpl(args, afero.NewOsFs())
 }
 
-func RunImpl(args []string, fs afero.IOFS) (statusCode int) {
+func RunImpl(args []string, fs afero.Fs) (statusCode int) {
 	var app *cli.App
 
 	if newCli, ok := os.LookupEnv("NEW_CLI"); ok && newCli != "0" {
@@ -57,7 +56,7 @@ func RunImpl(args []string, fs afero.IOFS) (statusCode int) {
 	return 0
 }
 
-func buildCli(fs afero.IOFS) *cli.App {
+func buildCli(fs afero.Fs) *cli.App {
 	fmt.Print(`You are currently using the old CLI structure which will be used by
 default until monaco version 2.0.0
 
@@ -172,7 +171,7 @@ Examples:
 	return app
 }
 
-func buildExperimentalCli(fs afero.IOFS) *cli.App {
+func buildExperimentalCli(fs afero.Fs) *cli.App {
 	fmt.Print(`You are using the new CLI structure which is currently in Beta.
 
 Please provide feedback here:
@@ -213,7 +212,7 @@ Examples:
 
 	return app
 }
-func getDeployCommand(fs afero.IOFS) cli.Command {
+func getDeployCommand(fs afero.Fs) cli.Command {
 	command := cli.Command{
 		Name:      "deploy",
 		Usage:     "deploys the given environment",
@@ -290,7 +289,7 @@ func getDeployCommand(fs afero.IOFS) cli.Command {
 	}
 	return command
 }
-func getDownloadCommand(fs afero.IOFS) cli.Command {
+func getDownloadCommand(fs afero.Fs) cli.Command {
 	command := cli.Command{
 		Name:      "download",
 		Usage:     "download the given environment",

--- a/cmd/monaco/multi_project_integration_test.go
+++ b/cmd/monaco/multi_project_integration_test.go
@@ -36,7 +36,7 @@ const multiProjectEnvironmentsFile = multiProjectFolder + "environments.yaml"
 // Tests all environments with all projects
 func TestIntegrationMultiProject(t *testing.T) {
 
-	RunIntegrationWithCleanup(t, multiProjectFolder, multiProjectEnvironmentsFile, "MultiProject", func(fs afero.IOFS) {
+	RunIntegrationWithCleanup(t, multiProjectFolder, multiProjectEnvironmentsFile, "MultiProject", func(fs afero.Fs) {
 
 		environments, errs := environment.LoadEnvironmentList("", multiProjectEnvironmentsFile, fs)
 		assert.Check(t, len(errs) == 0, "didn't expect errors loading test environments")
@@ -85,7 +85,7 @@ func TestIntegrationValidationMultiProjectWithoutEndingSlashInPath(t *testing.T)
 // tests a single project with dependencies
 func TestIntegrationMultiProjectSingleProject(t *testing.T) {
 
-	RunIntegrationWithCleanup(t, multiProjectFolder, multiProjectEnvironmentsFile, "MultiProjectSingleProject", func(fs afero.IOFS) {
+	RunIntegrationWithCleanup(t, multiProjectFolder, multiProjectEnvironmentsFile, "MultiProjectSingleProject", func(fs afero.Fs) {
 
 		environments, errs := environment.LoadEnvironmentList("", multiProjectEnvironmentsFile, fs)
 		FailOnAnyError(errs, "loading of environments failed")

--- a/cmd/monaco/multi_tenant_integration_test.go
+++ b/cmd/monaco/multi_tenant_integration_test.go
@@ -36,7 +36,7 @@ const environmentsFile = folder + "environments.yaml"
 // Tests all environments with all projects
 func TestIntegrationMultiEnvironment(t *testing.T) {
 
-	RunIntegrationWithCleanup(t, folder, environmentsFile, "MultiEnvironment", func(fs afero.IOFS) {
+	RunIntegrationWithCleanup(t, folder, environmentsFile, "MultiEnvironment", func(fs afero.Fs) {
 
 		environments, errs := environment.LoadEnvironmentList("", environmentsFile, fs)
 		assert.Check(t, len(errs) == 0, "didn't expect errors loading test environments")
@@ -72,7 +72,7 @@ func TestIntegrationValidationMultiEnvironment(t *testing.T) {
 // tests a single project
 func TestIntegrationMultiEnvironmentSingleProject(t *testing.T) {
 
-	RunIntegrationWithCleanup(t, folder, environmentsFile, "MultiEnvironmentSingleProject", func(fs afero.IOFS) {
+	RunIntegrationWithCleanup(t, folder, environmentsFile, "MultiEnvironmentSingleProject", func(fs afero.Fs) {
 
 		environments, errs := environment.LoadEnvironmentList("", environmentsFile, fs)
 		FailOnAnyError(errs, "loading of environments failed")
@@ -96,7 +96,7 @@ func TestIntegrationMultiEnvironmentSingleProject(t *testing.T) {
 // Tests a single project with dependency
 func TestIntegrationMultiEnvironmentSingleProjectWithDependency(t *testing.T) {
 
-	RunIntegrationWithCleanup(t, folder, environmentsFile, "MultiEnvironmentSingleProjectWithDependency", func(fs afero.IOFS) {
+	RunIntegrationWithCleanup(t, folder, environmentsFile, "MultiEnvironmentSingleProjectWithDependency", func(fs afero.Fs) {
 
 		environments, errs := environment.LoadEnvironmentList("", environmentsFile, fs)
 		FailOnAnyError(errs, "loading of environments failed")
@@ -122,7 +122,7 @@ func TestIntegrationMultiEnvironmentSingleProjectWithDependency(t *testing.T) {
 // tests a single environment
 func TestIntegrationMultiEnvironmentSingleEnvironment(t *testing.T) {
 
-	RunIntegrationWithCleanup(t, folder, environmentsFile, "MultiEnvironmentSingleEnvironment", func(fs afero.IOFS) {
+	RunIntegrationWithCleanup(t, folder, environmentsFile, "MultiEnvironmentSingleEnvironment", func(fs afero.Fs) {
 
 		environments, errs := environment.LoadEnvironmentList("", environmentsFile, fs)
 		FailOnAnyError(errs, "loading of environments failed")

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,7 @@ github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/X
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -51,6 +52,7 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e h1:aZzprAO9/8oim3qStq3wc1Xuxx4QmAGriC4VU4ojemQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,7 +65,7 @@ type configImpl struct {
 
 // configFactory is used to create new Configs - this is needed for testing purposes
 type ConfigFactory interface {
-	NewConfig(fs afero.IOFS, id string, project string, fileName string, properties map[string]map[string]string, api api.Api) (Config, error)
+	NewConfig(fs afero.Fs, id string, project string, fileName string, properties map[string]map[string]string, api api.Api) (Config, error)
 }
 
 type configFactoryImpl struct{}
@@ -74,7 +74,7 @@ func NewConfigFactory() ConfigFactory {
 	return &configFactoryImpl{}
 }
 
-func NewConfig(fs afero.IOFS, id string, project string, fileName string, properties map[string]map[string]string, api api.Api) (Config, error) {
+func NewConfig(fs afero.Fs, id string, project string, fileName string, properties map[string]map[string]string, api api.Api) (Config, error) {
 
 	template, err := util.NewTemplate(fs, fileName)
 	if err != nil {
@@ -390,7 +390,7 @@ func (c *configImpl) GetFullQualifiedId() string {
 }
 
 // NewConfig creates a new Config
-func (c *configFactoryImpl) NewConfig(fs afero.IOFS, id string, project string, fileName string, properties map[string]map[string]string, api api.Api) (Config, error) {
+func (c *configFactoryImpl) NewConfig(fs afero.Fs, id string, project string, fileName string, properties map[string]map[string]string, api api.Api) (Config, error) {
 	config, err := NewConfig(fs, id, project, fileName, properties, api)
 	if err != nil {
 		return nil, err

--- a/pkg/config/config_test_util.go
+++ b/pkg/config/config_test_util.go
@@ -36,7 +36,7 @@ func CreateConfigMockFactory(t *testing.T) *MockConfigFactory {
 	return NewMockConfigFactory(mockCtrl)
 }
 
-func GetMockConfig(fs afero.IOFS, id string, project string, template util.Template, properties map[string]map[string]string, api api.Api, fileName string) Config {
+func GetMockConfig(fs afero.Fs, id string, project string, template util.Template, properties map[string]map[string]string, api api.Api, fileName string) Config {
 
 	return newConfig(id, project, template, properties, api, fileName)
 }

--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -37,12 +37,12 @@ type deleteYaml struct {
 
 // LoadConfigsToDelete loads the delete.yaml file (if available) and converts its entries into configs which need
 // to be deleted
-func LoadConfigsToDelete(fs afero.IOFS, apis map[string]api.Api, path string) (configs []config.Config, err error) {
+func LoadConfigsToDelete(fs afero.Fs, apis map[string]api.Api, path string) (configs []config.Config, err error) {
 
 	result := make([]config.Config, 0)
 
 	deleteFilePath := filepath.Join(path, deleteFileName)
-	data, err := afero.ReadFile(fs.Fs, deleteFilePath)
+	data, err := afero.ReadFile(fs, deleteFilePath)
 	if err != nil {
 		// Don't raise an error. The delete.yaml might not be there, that's a valid case
 		util.Log.Info("There is no delete file %s found in %s. Skipping delete config.", deleteFileName, deleteFilePath)

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -31,7 +31,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func Deploy(workingDir string, fs afero.IOFS, environmentsFile string,
+func Deploy(workingDir string, fs afero.Fs, environmentsFile string,
 	specificEnvironment string, proj string, dryRun bool, continueOnError bool) error {
 	environments, errors := environment.LoadEnvironmentList(specificEnvironment, environmentsFile, fs)
 
@@ -252,7 +252,7 @@ func uploadConfig(client rest.DynatraceClient, config config.Config, dict map[st
 }
 
 // deleteConfigs deletes specified configs, if a delete.yaml file was found
-func deleteConfigs(apis map[string]api.Api, environments map[string]environment.Environment, path string, dryRun bool, fs afero.IOFS) error {
+func deleteConfigs(apis map[string]api.Api, environments map[string]environment.Environment, path string, dryRun bool, fs afero.Fs) error {
 	configs, err := delete.LoadConfigsToDelete(fs, apis, path)
 	util.FailOnError(err, "deletion failed")
 

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -31,7 +31,7 @@ import (
 var cont = 0
 
 //GetConfigsFilterByEnvironment filters the enviroments list based on specificEnvironment flag value
-func GetConfigsFilterByEnvironment(workingDir string, fs afero.IOFS, environmentsFile string,
+func GetConfigsFilterByEnvironment(workingDir string, fs afero.Fs, environmentsFile string,
 	specificEnvironment string, downloadSpecificAPI string) error {
 	environments, errors := environment.LoadEnvironmentList(specificEnvironment, environmentsFile, fs)
 	if len(errors) > 0 {
@@ -45,7 +45,7 @@ func GetConfigsFilterByEnvironment(workingDir string, fs afero.IOFS, environment
 }
 
 //getConfigs Entry point that retrieves the specified configurations from a Dynatrace tenant
-func getConfigs(fs afero.IOFS, workingDir string, environments map[string]environment.Environment, downloadSpecificAPI string) error {
+func getConfigs(fs afero.Fs, workingDir string, environments map[string]environment.Environment, downloadSpecificAPI string) error {
 	list, err := getAPIList(downloadSpecificAPI)
 	if err != nil {
 		return err
@@ -96,7 +96,7 @@ func getAPIList(downloadSpecificAPI string) (filterAPIList map[string]api.Api, e
 }
 
 //creates the project and downloads the configs
-func downloadConfigFromEnvironment(fs afero.IOFS, environment environment.Environment, basepath string, listApis map[string]api.Api) (err error) {
+func downloadConfigFromEnvironment(fs afero.Fs, environment environment.Environment, basepath string, listApis map[string]api.Api) (err error) {
 	projectName := environment.GetId()
 	path := filepath.Join(basepath, projectName)
 
@@ -129,7 +129,7 @@ func downloadConfigFromEnvironment(fs afero.IOFS, environment environment.Enviro
 	return nil
 }
 
-func createConfigsFromAPI(fs afero.IOFS, api api.Api, token string, fullpath string, client rest.DynatraceClient,
+func createConfigsFromAPI(fs afero.Fs, api api.Api, token string, fullpath string, client rest.DynatraceClient,
 	jcreator jsoncreator.JSONCreator, ycreator yamlcreator.YamlCreator) (err error) {
 	//retrieves all objects for the specific api
 	values, err := client.List(api)

--- a/pkg/download/jsoncreator/json_creator.go
+++ b/pkg/download/jsoncreator/json_creator.go
@@ -30,7 +30,7 @@ import (
 
 //JSONCreator interface allows to mock the methods for unit testing
 type JSONCreator interface {
-	CreateJSONConfig(fs afero.IOFS, client rest.DynatraceClient, api api.Api, value api.Value,
+	CreateJSONConfig(fs afero.Fs, client rest.DynatraceClient, api api.Api, value api.Value,
 		path string) (name string, cleanName string, filter bool, err error)
 }
 
@@ -44,7 +44,7 @@ func NewJSONCreator() *JsonCreatorImp {
 }
 
 //CreateJSONConfig creates a json file using the specified path and API data
-func (d *JsonCreatorImp) CreateJSONConfig(fs afero.IOFS, client rest.DynatraceClient, api api.Api, value api.Value,
+func (d *JsonCreatorImp) CreateJSONConfig(fs afero.Fs, client rest.DynatraceClient, api api.Api, value api.Value,
 	path string) (name string, cleanName string, filter bool, err error) {
 	data, filter, err := getDetailFromAPI(client, api, value.Id)
 	if err != nil {
@@ -60,7 +60,7 @@ func (d *JsonCreatorImp) CreateJSONConfig(fs afero.IOFS, client rest.DynatraceCl
 		return "", "", false, err
 	}
 	fullPath := filepath.Join(path, cleanName+".json")
-	err = afero.WriteFile(fs.Fs, fullPath, jsonfile, 0664)
+	err = afero.WriteFile(fs, fullPath, jsonfile, 0664)
 	if err != nil {
 		util.Log.Error("error writing detail %s", api.GetId())
 		return "", "", false, err

--- a/pkg/download/yamlcreator/yaml_creator.go
+++ b/pkg/download/yamlcreator/yaml_creator.go
@@ -26,7 +26,7 @@ import (
 
 //YamlCreator implements method to create the yaml configuration file
 type YamlCreator interface {
-	CreateYamlFile(fs afero.IOFS, path string, name string) error
+	CreateYamlFile(fs afero.Fs, path string, name string) error
 	AddConfig(name string, rawName string)
 }
 
@@ -59,7 +59,7 @@ func (yc *YamlConfig) AddConfig(name string, rawName string) {
 }
 
 //CreateYamlFile transforms the struct into a physical file on disk
-func (yc *YamlConfig) CreateYamlFile(fs afero.IOFS, path string, name string) error {
+func (yc *YamlConfig) CreateYamlFile(fs afero.Fs, path string, name string) error {
 
 	data, err := yaml.Marshal(yc)
 	if err != nil {
@@ -67,7 +67,7 @@ func (yc *YamlConfig) CreateYamlFile(fs afero.IOFS, path string, name string) er
 		return err
 	}
 	fullPath := filepath.Join(path, name+".yaml")
-	err = afero.WriteFile(fs.Fs, fullPath, data, 0664)
+	err = afero.WriteFile(fs, fullPath, data, 0664)
 	if err != nil {
 		util.Log.Error("error creating yaml file %s", name)
 		return err

--- a/pkg/environment/environment_loader.go
+++ b/pkg/environment/environment_loader.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func LoadEnvironmentList(specificEnvironment string, environmentsFile string, fs afero.IOFS) (environments map[string]Environment, errorList []error) {
+func LoadEnvironmentList(specificEnvironment string, environmentsFile string, fs afero.Fs) (environments map[string]Environment, errorList []error) {
 
 	if environmentsFile == "" {
 		errorList = append(errorList, errors.New("no environmentfile provided"))
@@ -54,9 +54,9 @@ func LoadEnvironmentList(specificEnvironment string, environmentsFile string, fs
 }
 
 // readEnvironments reads the yaml file for the environments and returns the parsed environments
-func readEnvironments(file string, fs afero.IOFS) (map[string]Environment, []error) {
+func readEnvironments(file string, fs afero.Fs) (map[string]Environment, []error) {
 
-	dat, err := afero.ReadFile(fs.Fs, file)
+	dat, err := afero.ReadFile(fs, file)
 	util.FailOnError(err, "Error while reading file")
 
 	err, environmentMaps := util.UnmarshalYaml(string(dat), file)

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -47,11 +47,11 @@ type projectBuilder struct {
 	configs           []config.Config
 	apis              map[string]api.Api
 	configFactory     config.ConfigFactory
-	fs                afero.IOFS
+	fs                afero.Fs
 }
 
 // NewProject loads a new project from folder. Returns either project or a reading/sorting error respectively.
-func NewProject(fs afero.IOFS, fullQualifiedProjectFolderName string, projectFolderName string, apis map[string]api.Api, projectRootFolder string) (Project, error) {
+func NewProject(fs afero.Fs, fullQualifiedProjectFolderName string, projectFolderName string, apis map[string]api.Api, projectRootFolder string) (Project, error) {
 
 	var configs = make([]config.Config, 0)
 
@@ -97,7 +97,7 @@ func warnIfProjectNameClashesWithApiName(projectFolderName string, apis map[stri
 }
 
 func (p *projectBuilder) readFolder(folder string, isProjectRoot bool) error {
-	files, err := afero.ReadDir(p.fs.Fs, folder)
+	files, err := afero.ReadDir(p.fs, folder)
 
 	if util.CheckError(err, "Folder "+folder+" could not be read") {
 		return err
@@ -123,7 +123,7 @@ func (p *projectBuilder) processYaml(filename string) error {
 
 	util.Log.Debug("Processing file: " + filename)
 
-	bytes, err := afero.ReadFile(p.fs.Fs, filename)
+	bytes, err := afero.ReadFile(p.fs, filename)
 
 	if util.CheckError(err, "Error while reading file "+filename) {
 		return err

--- a/pkg/project/project_loader.go
+++ b/pkg/project/project_loader.go
@@ -33,7 +33,7 @@ import (
 // if projects specified with -p parameter then it takes only those projects and
 // it also resolves all project dependencies
 // if no -p parameter specified, then it creates a list of all projects
-func LoadProjectsToDeploy(fs afero.IOFS, specificProjectToDeploy string, apis map[string]api.Api, path string) (projectsToDeploy []Project, err error) {
+func LoadProjectsToDeploy(fs afero.Fs, specificProjectToDeploy string, apis map[string]api.Api, path string) (projectsToDeploy []Project, err error) {
 
 	projectsFolder := filepath.Clean(path)
 	projectsToDeploy = make([]Project, 0)
@@ -100,7 +100,7 @@ func returnSortedProjects(projectsToDeploy []Project) ([]Project, error) {
 
 // takes project folder parameter and creates []Project slice
 // if project specified contains subprojects, then it adds subprojects instead
-func createProjectsListFromFolderList(fs afero.IOFS, path, specificProjectToDeploy string, projectsFolder string, apis map[string]api.Api, availableProjectFolders []string) ([]Project, error) {
+func createProjectsListFromFolderList(fs afero.Fs, path, specificProjectToDeploy string, projectsFolder string, apis map[string]api.Api, availableProjectFolders []string) ([]Project, error) {
 	projectsToDeploy := make([]Project, 0)
 	multiProjects := strings.Split(specificProjectToDeploy, ",")
 	for _, projectFolderName := range multiProjects {
@@ -184,9 +184,9 @@ func hasSubprojectFolder(projectFolder string, projectFolders []string) bool {
 // walks through a path recursively and searches for all folders
 // ignores folders with configurations (containing api configs) and hidden folders
 // fails if a folder with both sub projects and api configs are found
-func getAllProjectFoldersRecursively(fs afero.IOFS, path string) ([]string, error) {
+func getAllProjectFoldersRecursively(fs afero.Fs, path string) ([]string, error) {
 	var allProjectsFolders []string
-	err := afero.Walk(fs.Fs, path, func(path string, info os.FileInfo, err error) error {
+	err := afero.Walk(fs, path, func(path string, info os.FileInfo, err error) error {
 		if info == nil {
 			return fmt.Errorf("Project path does not exist: %s. (This needs to be a relative path from the current directory)", path)
 		}
@@ -204,13 +204,13 @@ func getAllProjectFoldersRecursively(fs afero.IOFS, path string) ([]string, erro
 	return filterProjectsWithSubproject(allProjectsFolders), nil
 }
 
-func subprojectsMixedWithApi(fs afero.IOFS, path string) error {
+func subprojectsMixedWithApi(fs afero.Fs, path string) error {
 	apiFound, subprojectFound := false, false
 	_, err := fs.Open(path)
 	if err != nil {
 		return err
 	}
-	dirs, err := fs.ReadDir(path)
+	dirs, err := afero.ReadDir(fs, path)
 	if err != nil {
 		return err
 	}

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -39,7 +39,7 @@ func testCreateProjectBuilder(projectsRoot string) projectBuilder {
 	}
 }
 
-func testCreateProjectBuilderWithMock(factory config.ConfigFactory, fs afero.IOFS, projectId string, projectsRoot string) projectBuilder {
+func testCreateProjectBuilderWithMock(factory config.ConfigFactory, fs afero.Fs, projectId string, projectsRoot string) projectBuilder {
 
 	return projectBuilder{
 		projectRootFolder: projectsRoot,
@@ -148,8 +148,8 @@ func TestGetApiFromLocationApiNotFound(t *testing.T) {
 func TestProcessConfigSection(t *testing.T) {
 
 	factory := config.CreateConfigMockFactory(t)
-	fileReaderMock := util.CreateTestFileSystem()
-	builder := testCreateProjectBuilderWithMock(factory, fileReaderMock, "testProject", "")
+	fs := util.CreateTestFileSystem()
+	builder := testCreateProjectBuilderWithMock(factory, fs, "testProject", "")
 
 	m := make(map[string]map[string]string)
 
@@ -160,8 +160,8 @@ func TestProcessConfigSection(t *testing.T) {
 
 	zoneA := util.ReplacePathSeparators("test/management-zone/zoneA.json")
 	profile := util.ReplacePathSeparators("test/alerting-profile/profile.json")
-	factory.EXPECT().NewConfig(fileReaderMock, "test1", "testProject", zoneA, m, testManagementZoneApi).Times(1)
-	factory.EXPECT().NewConfig(fileReaderMock, "test2", "testProject", profile, m, testAlertingProfileApi).Times(1)
+	factory.EXPECT().NewConfig(fs, "test1", "testProject", zoneA, m, testManagementZoneApi).Times(1)
+	factory.EXPECT().NewConfig(fs, "test2", "testProject", profile, m, testAlertingProfileApi).Times(1)
 
 	folderPath := util.ReplacePathSeparators("test/management-zone")
 	err := builder.processConfigSection(m, folderPath)
@@ -243,19 +243,19 @@ dashboard.dev:
 func TestProcessYaml(t *testing.T) {
 
 	factory := config.CreateConfigMockFactory(t)
-	fileReaderMock := util.CreateTestFileSystem()
-	err := fileReaderMock.Mkdir("test/dashboard/", 0777)
-	err = afero.WriteFile(fileReaderMock.Fs, "test/dashboard/test-file.yaml", []byte(projectTestYaml), 0664)
+	fs := util.CreateTestFileSystem()
+	err := fs.Mkdir("test/dashboard/", 0777)
+	err = afero.WriteFile(fs, "test/dashboard/test-file.yaml", []byte(projectTestYaml), 0664)
 
-	builder := testCreateProjectBuilderWithMock(factory, fileReaderMock, "testproject", "")
+	builder := testCreateProjectBuilderWithMock(factory, fs, "testproject", "")
 
 	properties := make(map[string]map[string]string)
 
 	yamlFile := util.ReplacePathSeparators("test/dashboard/test-file.yaml")
 
 	factory.EXPECT().
-		NewConfig(fileReaderMock, "dashboard", "testproject", util.ReplacePathSeparators("test/dashboard/my-project-dashboard.json"), gomock.Any(), testDashboardApi).
-		Return(config.GetMockConfig(fileReaderMock, "my-project-dashboard", "testproject", nil, properties, testDashboardApi, util.ReplacePathSeparators("dashboard/test-file.yaml")), nil)
+		NewConfig(fs, "dashboard", "testproject", util.ReplacePathSeparators("test/dashboard/my-project-dashboard.json"), gomock.Any(), testDashboardApi).
+		Return(config.GetMockConfig(fs, "my-project-dashboard", "testproject", nil, properties, testDashboardApi, util.ReplacePathSeparators("dashboard/test-file.yaml")), nil)
 
 	err = builder.processYaml(yamlFile)
 

--- a/pkg/util/afero_utils.go
+++ b/pkg/util/afero_utils.go
@@ -23,12 +23,10 @@ import (
 //CreateTestFileSystem creates a virtual filesystem with 2 layers.
 //The first layer allows to read file from the disk
 //the second layer allows to modify files on a virtual filesystem
-func CreateTestFileSystem() afero.IOFS {
+func CreateTestFileSystem() afero.Fs {
 	base := afero.NewOsFs()
 	baseLayer := afero.NewReadOnlyFs(base)
-	fs := afero.NewCopyOnWriteFs(baseLayer, afero.NewMemMapFs())
-	fsStdlib := afero.NewIOFS(fs)
-	return fsStdlib
+	return afero.NewCopyOnWriteFs(baseLayer, afero.NewMemMapFs())
 }
 
 //SanitizeName removes special characters, limits to max 254 characters in name, no special characters

--- a/pkg/util/template.go
+++ b/pkg/util/template.go
@@ -19,7 +19,6 @@ package util
 import (
 	"bytes"
 	"os"
-	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -50,15 +49,14 @@ func NewTemplateFromString(name string, content string) (Template, error) {
 }
 
 // NewTemplate creates a new template for the given file
-func NewTemplate(fs afero.IOFS, fileName string) (Template, error) {
-	cleanedFilename := filepath.Clean(fileName)
+func NewTemplate(fs afero.Fs, fileName string) (Template, error) {
+	data, err := afero.ReadFile(fs, fileName)
 
-	templ, err := template.ParseFS(fs, cleanedFilename)
 	if err != nil {
 		return nil, err
 	}
 
-	return newTemplate(templ), nil
+	return NewTemplateFromString(fileName, string(data))
 }
 
 func newTemplate(templ *template.Template) Template {

--- a/pkg/util/test_config_rewrite.go
+++ b/pkg/util/test_config_rewrite.go
@@ -25,8 +25,8 @@ import (
 )
 
 //rewriteConfigNames reads the config from the config folder and rewrites the files on a inmemory filesystem.
-func RewriteConfigNames(path string, fs afero.IOFS, transformers []func(string) string) error {
-	files, err := afero.ReadDir(fs.Fs, path)
+func RewriteConfigNames(path string, fs afero.Fs, transformers []func(string) string) error {
+	files, err := afero.ReadDir(fs, path)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/test_utils_test.go
+++ b/pkg/util/test_utils_test.go
@@ -77,7 +77,7 @@ func assertInMemoryReplace(t *testing.T, transformers []func(string) string, exp
 	err := RewriteConfigNames("test-resources", reader, transformers)
 	assert.NilError(t, err)
 
-	content, err := afero.ReadFile(reader.Fs, "test-resources/test-environments.yaml")
+	content, err := afero.ReadFile(reader, "test-resources/test-environments.yaml")
 	assert.NilError(t, err)
 
 	assert.Check(t, strings.Contains(string(content), expected), "content '%s' was invalid", content)


### PR DESCRIPTION
By definition (1) golangs filesystem abstraction doesn't support
absolute paths. Since we need absolute paths to work, every use of
afero.IOFS has been replaced with just afero.Fs. In order to use golangs
abstraction some further research and prototyping is needed.

(1) https://go.googlesource.com/proposal/+/master/design/draft-iofs.md#file-name-syntax