### PR TITLE
fix: References on pre-existing SLOs do not work

### DIFF
--- a/cmd/monaco/test-resources/integration-all-configs/only-post/application-mobile/mobile-application.json
+++ b/cmd/monaco/test-resources/integration-all-configs/only-post/application-mobile/mobile-application.json
@@ -8,6 +8,7 @@
       "frustratedOnError": true
     },
     "optInModeEnabled": true,
+    "sessionReplayEnabled": true,
     "sessionReplayOnCrashEnabled": true,
     "beaconEndpointType": "CLUSTER_ACTIVE_GATE"
   }


### PR DESCRIPTION
The SLO API returns http status code `200` or `201` when updating an
existing config. Previously, `monaco` just listened for the `204` status
code on update. This commit changes the behavior and makes the response
checking more explicit.

fixes #288