### PR TITLE
Release 1.5.3

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Monitoring as Code Tool - Release Notes
 
 - Versions:
+  - [1.5.3](#153)
   - [1.5.2](#152)
   - [1.5.1](#151)
   - [1.5.0](#150)
@@ -11,6 +12,11 @@
   - [1.1.0](#110)
   - [1.0.1](#101)
   - [1.0.0](#100)
+
+## 1.5.3
+
+#### Bugfixes
+* 7b0cfae Bugfix #307 multiple dependencies with relative path resolution not working (#307)
 
 ## 1.5.2
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -353,8 +353,6 @@ func (c *configImpl) HasDependencyOn(config Config) bool {
 					if valueString == strings.Join([]string{config.GetType(), config.GetId()}, string(os.PathSeparator)) {
 						config.addToRequiredByConfigIdList(c.GetFullQualifiedId())
 						return true
-					} else {
-						return false
 					}
 				}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -424,6 +424,23 @@ func TestHasDependencyCheck(t *testing.T) {
 	assert.Equal(t, true, config.HasDependencyOn(otherConfig))
 }
 
+func TestHasDependencyWithMultipleDependenciesCheck(t *testing.T) {
+	prop := make(map[string]map[string]string)
+	prop["test"] = make(map[string]string)
+	prop["test"]["name"] = "A name"
+
+	prop["test"]["someDependency"] = "management-zone/not-existing-dep.name"
+	prop["test"]["somethingelse"] = util.ReplacePathSeparators("management-zone/other.id")
+	temp, e := util.NewTemplateFromString("test", "{{.name}}{{.somethingelse}}")
+	assert.NilError(t, e)
+
+	config := newConfig("test", "testproject", temp, prop, testManagementZoneApi, "test.json")
+
+	otherConfig := newConfig("other", "testproject", temp, make(map[string]map[string]string), testManagementZoneApi, "other.json")
+
+	assert.Equal(t, true, config.HasDependencyOn(otherConfig))
+}
+
 func TestMeIdRegex(t *testing.T) {
 	assert.Check(t, isMeId("HOST_GROUP-95BEC188F318D09C"))
 	assert.Check(t, isMeId("APPLICATION-95BEC188F318D09C"))

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,4 +16,4 @@
 
 package version
 
-const MonitoringAsCode = "1.5.2"
+const MonitoringAsCode = "1.5.3"


### PR DESCRIPTION
This commit extends the documentation for monaco version 1.5.3 and sets its version. Monaco 1.5.3 contains the following changes:
* 7b0cfae Bugfix #307 multiple dependencies with relative path resolution not working (#307)