### PR TITLE
Release 1.5.3

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Monitoring as Code Tool - Release Notes
 
 - Versions:
+  - [1.5.3](#153)
   - [1.5.2](#152)
   - [1.5.1](#151)
   - [1.5.0](#150)
@@ -11,6 +12,14 @@
   - [1.1.0](#110)
   - [1.0.1](#101)
   - [1.0.0](#100)
+
+## 1.5.3
+
+### List of changes
+
+#### Bugfixes
+* 7b0cfae Bugfix #307 multiple dependencies with relative path resolution not working
+
 
 ## 1.5.2
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,4 +16,4 @@
 
 package version
 
-const MonitoringAsCode = "1.5.2"
+const MonitoringAsCode = "1.5.3"


### PR DESCRIPTION
This commit extends the documentation for monaco version 1.5.3 and sets its version. Monaco 1.5.3 contains the following changes:
* 7b0cfae Bugfix #307 multiple dependencies with relative path resolution not working (#307)