### PR TITLE
fix: Upsert objects with special chars no longer fail

### DIFF
--- a/pkg/rest/config_upload.go
+++ b/pkg/rest/config_upload.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -155,9 +156,9 @@ func upsertDynatraceObject(client *http.Client, fullUrl string, objectName strin
 
 func joinUrl(urlBase string, path string) string {
 	if strings.HasSuffix(urlBase, "/") {
-		return urlBase + path
+		return urlBase + url.PathEscape(path)
 	}
-	return urlBase + "/" + path
+	return urlBase + "/" + url.PathEscape(path)
 }
 
 func isLocationHeaderAvailable(resp Response) (headerAvailable bool, headerArray []string) {


### PR DESCRIPTION
There was an issue with the way we build the upsert urls. If the id of
an object contained any special char such as `%`, it would fail the
upsert request. To overcome this issues, all IDs are now URL-Path
encoded.

*Note:* there seem to be an issue with the dynatrace anomaly-detection api
that prevent updating build-in anomaly-detection-metrics with `%` in their name. 

fixes #248 