### PR TITLE
Update experimental-new-cli.md

### DIFF
--- a/documentation/versioned_docs/version-1.6.0/commands/experimental-new-cli.md
+++ b/documentation/versioned_docs/version-1.6.0/commands/experimental-new-cli.md
@@ -27,3 +27,9 @@ This command is basically doing what the old tool did. It is used to deploy a sp
 ### Download
 
 This feature allows you to download the configuration from a Dynatrace tenant as Monaco files. You can use this feature to avoid starting from scratch when using Monaco.
+
+### Dry run 
+To validate a configuration while using the new CLI version, use the `deploy` command with the flag, `--dry-run`. For example, 
+```
+$ ./monaco deploy --dry-run <any other arguments>
+```


### PR DESCRIPTION
Adding a note about using --dry-run with the new CLI. 

The current docs has an example, `monaco -dry-run` which does not work with the new CLI (as it requires the user to specify the command, either `deploy` or `download`). 
It might also be useful to add a similar note to the "Validating Configuration" page as well.