### PR TITLE
docs: Removed duplicate lines in "yaml_config.md"

### DIFF
--- a/documentation/docs/configuration/yaml_confg.md
+++ b/documentation/docs/configuration/yaml_confg.md
@@ -131,8 +131,6 @@ application-tagging-multiproject:
 
 In this example, `application-tagging.json` is located in `auto-tag` folder of same project and the path to it
 can be defined relative to `auto-tag.yaml` file. But, what if you would like to reuse one template defined outside of this project?
- can be defined relative to `auto-tag.yaml` file. But, what if you would like to reuse one template defined outside of this project?
-can be defined relative to `auto-tag.yaml` file. But, what if you would like to reuse one template defined outside of this project?
 In this case, you need to define a full path of json template:
 
 **testproject/auto-tag/auto-tag.yaml:**


### PR DESCRIPTION
Removed duplicate lines relating to referencing other json templates

#can be defined relative to auto-tag.yaml file. But, what if you would like to reuse one template defined outside of this project?#