### PR TITLE
fix: Check status code in extension validation to allow uploading new extensions again

### DIFF
--- a/pkg/rest/extension_upload.go
+++ b/pkg/rest/extension_upload.go
@@ -84,6 +84,9 @@ func validateIfExtensionShouldBeUploaded(client *http.Client, apiPath string, ex
 	if err != nil {
 		return extensionValidationError, err
 	}
+	if response.StatusCode == http.StatusNotFound {
+		return extensionNeedsUpdate, nil
+	}
 	var extProperties struct{ Version *string }
 	if err := json.Unmarshal(response.Body, &extProperties); err != nil {
 		return extensionValidationError, err

--- a/pkg/rest/extension_upload_test.go
+++ b/pkg/rest/extension_upload_test.go
@@ -67,6 +67,17 @@ func TestCorrectlyIdentifiesNecessaryUpdate(t *testing.T) {
 	assert.Equal(t, status, extensionNeedsUpdate)
 }
 
+func TestCorrectlyIdentifiesMissingExtension(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	status, err := validateIfExtensionShouldBeUploaded(server.Client(), server.URL, "name", nil, "token")
+	assert.NilError(t, err)
+	assert.Equal(t, status, extensionNeedsUpdate)
+}
+
 func TestThrowsErrorOnRemoteParsingProblems(t *testing.T) {
 	localPayload := `{ "version": "1.5" }`
 	remotePayload := `{ "version "1" `


### PR DESCRIPTION
If a new extension is to be uploaded, there is no current version, so the
validation step returned an error for that. With this we check if an
extension doesn't exist at all before uploading, in which case we can
safely upload this new extension

fix: #125