### PR TITLE
Small bugfixes in converter

### DIFF
--- a/pkg/config/v2/parameter/reference/reference.go
+++ b/pkg/config/v2/parameter/reference/reference.go
@@ -134,7 +134,7 @@ func writeReferenceParameter(context parameter.ParameterWriterContext) (map[stri
 	sameApi := context.Coordinate.Api == refParam.Config.Api
 	sameConfig := context.Coordinate.Config == refParam.Config.Config
 
-	if sameProject {
+	if !sameProject {
 		result["project"] = refParam.Config.Project
 	}
 

--- a/pkg/manifest/manifest_persitence.go
+++ b/pkg/manifest/manifest_persitence.go
@@ -17,7 +17,7 @@ package manifest
 type project struct {
 	Name string  `yaml:"name"`
 	Type *string `yaml:"type,omitempty"`
-	Path string  `yaml:"path"`
+	Path string  `yaml:"path,omitempty"`
 }
 
 type tokenConfig struct {

--- a/pkg/manifest/manifest_writer.go
+++ b/pkg/manifest/manifest_writer.go
@@ -62,10 +62,19 @@ func persistManifestToDisk(context *ManifestWriterContext, m manifest) error {
 func toWriteableProjects(projects map[string]ProjectDefinition) []project {
 	var result []project
 
-	for projectName, projectDefinition := range projects {
-		p := project{
-			Name: projectName,
-			Path: projectDefinition.Path,
+	//TODO detect grouping projects
+	for _, projectDefinition := range projects {
+		var p project
+
+		if projectDefinition.Name != projectDefinition.Path {
+			p = project{
+				Name: projectDefinition.Name,
+				Path: projectDefinition.Path,
+			}
+		} else {
+			p = project{
+				Name: projectDefinition.Name,
+			}
 		}
 
 		result = append(result, p)


### PR DESCRIPTION
When persisting reference parameters there was a bug, setting the project property wrong.

The manifest converter doesn't have to write name and path if both are the same for simple projects.