### PR TITLE
feat: Introduce compound parameter type

### DIFF
--- a/documentation/docs/configuration/parameters.md
+++ b/documentation/docs/configuration/parameters.md
@@ -36,8 +36,8 @@ parameters:
   complexThreshold:
     type: value
     value:
-        amount: 15
-        unit: sec
+      amount: 15
+      unit: sec
 ```
 
 In the template of this config you could then access the `threshold`
@@ -139,4 +139,65 @@ configs:
     parameters:
       zoneId: ["infrastructure", "management-zone", "main", "id"]
       devZoneId: ["management-zone", "development", "id"]
+```
+
+## Compound Parameter
+
+The compound parameter is a parameter composed of other parameters of the same
+config. This parameters requires 2 properties: a `format` string and a list of
+`references` to all referenced parameters. Both properties are required.
+The `format` string can be any string, and to use parameters in it, the
+following syntax is used: `{{ .parameter }}`, where <parameter> is the
+name of the parameter that will be filled in. A simple example might look like this:
+
+```yaml
+parameters:
+  example:
+    type: compound
+    format: "{{ .greeting }} {{ .entity }}!"
+    references:
+      - greeting
+      - entity
+  greeting: "Hello"
+  entity: "World"
+```
+
+This would produce the value `Hello World!` for `example`. Compound parameters
+can also be used for more complex values, as seen in the following example:
+
+```yaml
+parameters:
+  example:
+    type: compound
+    format: "{{ .resource.name }}: {{ .resource.percent }}%"
+    references:
+      - resource
+  progress:
+    type: value
+    value:
+      name: "Health"
+      percent: 40
+```
+
+This would produce the value `Health: 40%` for example.
+Even though referenced parameters can only be from the same config,
+by using the reference parameter it is possible to make a compound
+parameters with other configs. The same goes for environment variables.
+
+```yaml
+parameters:
+  example:
+    type: compound
+    format: "{{ .user }}'s dashboard is {{ .status }}"
+    references:
+      - user
+      - status
+  user:
+    type: environment
+    name: USER_NAME
+  status:
+    type: reference
+    api: dashboard
+    config: dashboard
+    property: status
 ```

--- a/pkg/config/v2/config.go
+++ b/pkg/config/v2/config.go
@@ -17,6 +17,7 @@ package v2
 import (
 	"github.com/dynatrace-oss/dynatrace-monitoring-as-code/pkg/config/v2/coordinate"
 	"github.com/dynatrace-oss/dynatrace-monitoring-as-code/pkg/config/v2/parameter"
+	compoundParam "github.com/dynatrace-oss/dynatrace-monitoring-as-code/pkg/config/v2/parameter/compound"
 	envParam "github.com/dynatrace-oss/dynatrace-monitoring-as-code/pkg/config/v2/parameter/environment"
 	refParam "github.com/dynatrace-oss/dynatrace-monitoring-as-code/pkg/config/v2/parameter/reference"
 	valueParam "github.com/dynatrace-oss/dynatrace-monitoring-as-code/pkg/config/v2/parameter/value"
@@ -76,4 +77,5 @@ var DefaultParameterParsers = map[string]parameter.ParameterSerDe{
 	refParam.ReferenceParameterType:           refParam.ReferenceParameterSerde,
 	valueParam.ValueParameterType:             valueParam.ValueParameterSerde,
 	envParam.EnvironmentVariableParameterType: envParam.EnvironmentVariableParameterSerde,
+	compoundParam.CompoundParameterType:       compoundParam.CompoundParameterSerde,
 }

--- a/pkg/config/v2/parameter/compound/compound.go
+++ b/pkg/config/v2/parameter/compound/compound.go
@@ -1,0 +1,180 @@
+// @license
+// Copyright 2021 Dynatrace LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compound
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	"github.com/dynatrace-oss/dynatrace-monitoring-as-code/pkg/config/v2/coordinate"
+	"github.com/dynatrace-oss/dynatrace-monitoring-as-code/pkg/config/v2/errors"
+	"github.com/dynatrace-oss/dynatrace-monitoring-as-code/pkg/config/v2/parameter"
+	"github.com/dynatrace-oss/dynatrace-monitoring-as-code/pkg/util"
+)
+
+// CompoundParameterType specifies the type of the parameter used in config files
+const CompoundParameterType = "compound"
+
+var CompoundParameterSerde = parameter.ParameterSerDe{
+	Serializer:   writeCompoundParameter,
+	Deserializer: parseCompoundParameter,
+}
+
+type CompoundParameter struct {
+	format               *template.Template
+	rawFormatString      string
+	referencedParameters []parameter.ParameterReference
+}
+
+// this forces the compiler to check if CompoundParameter is of type Parameter
+var _ parameter.Parameter = (*CompoundParameter)(nil)
+
+func (p *CompoundParameter) GetType() string {
+	return CompoundParameterType
+}
+
+func (p *CompoundParameter) GetReferences() []parameter.ParameterReference {
+	return p.referencedParameters
+}
+
+func (p *CompoundParameter) ResolveValue(context parameter.ResolveContext) (interface{}, error) {
+	compoundData := make(map[string]interface{})
+
+	for _, param := range p.referencedParameters {
+		compoundData[param.Property] = context.ResolvedParameterValues[param.Property]
+	}
+
+	out := bytes.Buffer{}
+	err := p.format.Execute(&out, compoundData)
+
+	if err != nil {
+		return nil, fmt.Errorf("error resolving compound value: %v", err)
+	}
+
+	return out.String(), nil
+
+}
+
+// parseCompoundParameter parses a given context into an instance of CompoundParameter.
+// This requires a string `format` and a slice of strings `references`, where `format`
+// is a template string and `references` are all the used references in `format` refering
+// to other parameters within the config.
+func parseCompoundParameter(context parameter.ParameterParserContext) (parameter.Parameter, error) {
+	formatInterface, ok := context.Value["format"]
+	if !ok {
+		return nil, createParameterParseError(context, "missing property `format`")
+	}
+
+	format, err := template.New(context.ParameterName).Option("missingkey=error").Parse(util.ToString(formatInterface))
+	if err != nil {
+		return nil, createParameterParseError(context, "format is not a valid template: %v", err)
+	}
+
+	references, ok := context.Value["references"]
+	if !ok {
+		return nil, createParameterParseError(context, "missing property `references`")
+	}
+
+	referencedParameterSlice, ok := references.([]interface{})
+	if !ok {
+		return nil, createParameterParseError(context, "malformed value `references`")
+	}
+
+	referencedParameters, err := toParameterReferences(referencedParameterSlice, context.Coordinate)
+	if err != nil {
+		return nil, createParameterParseError(context, "invalid parameter references: %v", err)
+	}
+
+	return &CompoundParameter{
+		format:               format,
+		rawFormatString:      util.ToString(formatInterface),
+		referencedParameters: referencedParameters,
+	}, nil
+}
+
+func writeCompoundParameter(context parameter.ParameterWriterContext) (map[string]interface{}, error) {
+	compoundParam, ok := context.Parameter.(*CompoundParameter)
+
+	if !ok {
+		return nil, &parameter.ParameterWriterError{
+			Location: context.Coordinate,
+			EnvironmentDetails: errors.EnvironmentDetails{
+				Group:       context.Group,
+				Environment: context.Environment,
+			},
+			ParameterName: context.ParameterName,
+			Reason:        "unexpected type. parameter is not of type `CompoundParameter`",
+		}
+	}
+
+	result := make(map[string]interface{})
+
+	if compoundParam.rawFormatString == "" {
+		return nil, createParameterWriteError(context, "missing property `format`")
+	}
+	result["format"] = compoundParam.rawFormatString
+
+	if len(compoundParam.referencedParameters) == 0 {
+		return nil, createParameterWriteError(context, "missing property `references`")
+	}
+	references := make([]interface{}, len(compoundParam.referencedParameters))
+
+	for i, reference := range compoundParam.referencedParameters {
+		references[i] = reference.Property
+	}
+	result["references"] = references
+
+	return result, nil
+}
+
+func createParameterParseError(context parameter.ParameterParserContext, reason string, a ...interface{}) error {
+	return &parameter.ParameterParserError{
+		Location: context.Coordinate,
+		EnvironmentDetails: errors.EnvironmentDetails{
+			Group:       context.Group,
+			Environment: context.Environment,
+		},
+		ParameterName: context.ParameterName,
+		Reason:        fmt.Sprintf(reason, a...),
+	}
+}
+
+func createParameterWriteError(context parameter.ParameterWriterContext, reason string, a ...interface{}) error {
+	return &parameter.ParameterWriterError{
+		Location: context.Coordinate,
+		EnvironmentDetails: errors.EnvironmentDetails{
+			Group:       context.Group,
+			Environment: context.Environment,
+		},
+		ParameterName: context.ParameterName,
+		Reason:        fmt.Sprintf(reason, a...),
+	}
+}
+
+func toParameterReferences(params []interface{}, coord coordinate.Coordinate) (paramRefs []parameter.ParameterReference, err error) {
+	for _, param := range params {
+		switch param.(type) {
+		case []interface{}, map[interface{}]interface{}:
+			return nil, fmt.Errorf("error creating parameter reference: %v is not a string", param)
+		}
+
+		paramRefs = append(paramRefs, parameter.ParameterReference{
+			Config:   coord,
+			Property: util.ToString(param),
+		})
+	}
+	return paramRefs, nil
+}

--- a/pkg/config/v2/parameter/compound/compound_test.go
+++ b/pkg/config/v2/parameter/compound/compound_test.go
@@ -1,0 +1,223 @@
+// @license
+// Copyright 2021 Dynatrace LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build unit
+
+package compound
+
+import (
+	"testing"
+	"text/template"
+
+	"github.com/dynatrace-oss/dynatrace-monitoring-as-code/pkg/config/v2/parameter"
+	"github.com/dynatrace-oss/dynatrace-monitoring-as-code/pkg/config/v2/parameter/value"
+	"github.com/dynatrace-oss/dynatrace-monitoring-as-code/pkg/util"
+	"gotest.tools/assert"
+)
+
+func TestParseCompoundParameter(t *testing.T) {
+	param, err := parseCompoundParameter(parameter.ParameterParserContext{
+		Value: map[string]interface{}{
+			"format":     "{{ .firstName }} {{ .lastName }}",
+			"references": []interface{}{"firstName", "lastName"},
+		},
+	})
+
+	assert.NilError(t, err)
+
+	compoundParameter, ok := param.(*CompoundParameter)
+	assert.Assert(t, ok, "parsed parameter should be compound parameter")
+
+	assert.Equal(t, len(compoundParameter.referencedParameters), 2, "should be referencing 2 parameters")
+	assert.Equal(t, compoundParameter.referencedParameters[0].Property, "firstName")
+	assert.Equal(t, compoundParameter.referencedParameters[1].Property, "lastName")
+}
+
+func TestParseCompoundParameterComplexValue(t *testing.T) {
+	param, err := parseCompoundParameter(parameter.ParameterParserContext{
+		Value: map[string]interface{}{
+			"format":     "{{ .person.name }}: {{ .person.age }}",
+			"references": []interface{}{"person"},
+		},
+	})
+
+	assert.NilError(t, err)
+
+	compoundParameter, ok := param.(*CompoundParameter)
+	assert.Assert(t, ok, "parsed parameter should be compound parameter")
+
+	assert.Equal(t, len(compoundParameter.referencedParameters), 1, "should be referencing 1")
+	assert.Equal(t, compoundParameter.referencedParameters[0].Property, "person")
+}
+
+func TestParseCompoundParameterErrorOnMissingFormat(t *testing.T) {
+	_, err := parseCompoundParameter(parameter.ParameterParserContext{
+		Value: map[string]interface{}{
+			"references": []interface{}{"firstName", "lastName"},
+		},
+	})
+
+	assert.ErrorContains(t, err, "missing property `format`")
+}
+
+func TestParseCompoundParameterErrorOnMissingReferences(t *testing.T) {
+	_, err := parseCompoundParameter(parameter.ParameterParserContext{
+		Value: map[string]interface{}{
+			"format": "{{ .firstName }} {{ .lastName }}",
+		},
+	})
+
+	assert.ErrorContains(t, err, "missing property `references`")
+}
+
+func TestParseCompoundParameterErrorOnWrongReferenceFormat(t *testing.T) {
+	_, err := parseCompoundParameter(parameter.ParameterParserContext{
+		Value: map[string]interface{}{
+			"format":     "{{ .firstName }} {{ .lastName }}",
+			"references": []int{3, 4},
+		}})
+
+	assert.ErrorContains(t, err, "malformed value `references`")
+}
+
+func TestResolveValue(t *testing.T) {
+	testFormat, _ := template.New("").Option("missingkey=error").Parse("{{ .greeting }} {{ .entity }}!")
+	context := parameter.ResolveContext{
+		ResolvedParameterValues: parameter.Properties{
+			"greeting": "Hello",
+			"entity":   "World",
+		},
+	}
+	compoundParameter := CompoundParameter{
+		format: testFormat,
+		referencedParameters: []parameter.ParameterReference{
+			parameter.ParameterReference{Property: "greeting"},
+			parameter.ParameterReference{Property: "entity"},
+		},
+	}
+
+	result, err := compoundParameter.ResolveValue(context)
+	assert.NilError(t, err)
+
+	assert.Equal(t, "Hello World!", util.ToString(result))
+}
+
+func TestResolveComplexValue(t *testing.T) {
+	testFormat, _ := template.New("").Option("missingkey=error").Parse("{{ .person.name }} is {{ .person.age }} years old")
+	context := parameter.ResolveContext{
+		ResolvedParameterValues: parameter.Properties{
+			"person": map[string]interface{}{
+				"age":  12,
+				"name": "Hansi",
+			},
+		},
+	}
+	compoundParameter := CompoundParameter{
+		format: testFormat,
+		referencedParameters: []parameter.ParameterReference{
+			parameter.ParameterReference{Property: "person"},
+		},
+	}
+
+	result, err := compoundParameter.ResolveValue(context)
+	assert.NilError(t, err)
+
+	assert.Equal(t, "Hansi is 12 years old", util.ToString(result))
+}
+
+func TestResolveValueErrorOnUndefinedReference(t *testing.T) {
+	testFormat, _ := template.New("").Option("missingkey=error").Parse("{{ .firstName }} {{ .lastName }}")
+	context := parameter.ResolveContext{
+		ResolvedParameterValues: parameter.Properties{
+			"person": map[string]interface{}{
+				"age":  12,
+				"name": "Hansi",
+			},
+		},
+	}
+	compoundParameter := CompoundParameter{
+		format: testFormat,
+		referencedParameters: []parameter.ParameterReference{
+			parameter.ParameterReference{Property: "firstName"},
+		},
+	}
+
+	_, err := compoundParameter.ResolveValue(context)
+
+	assert.ErrorContains(t, err, `map has no entry for key "lastName"`)
+}
+
+func TestWriteCompoundParameter(t *testing.T) {
+	testFormat := "{{ .firstName }} {{ .lastName }}"
+	testRef1 := "firstName"
+	testRef2 := "lastName"
+	compoundParameter := CompoundParameter{
+		rawFormatString: testFormat,
+		referencedParameters: []parameter.ParameterReference{
+			parameter.ParameterReference{Property: testRef1},
+			parameter.ParameterReference{Property: testRef2},
+		},
+	}
+
+	context := parameter.ParameterWriterContext{Parameter: &compoundParameter}
+
+	result, err := writeCompoundParameter(context)
+	assert.NilError(t, err)
+
+	assert.Equal(t, len(result), 2)
+
+	format, ok := result["format"]
+	assert.Assert(t, ok, "should have parameter format")
+	assert.Equal(t, format, testFormat)
+
+	references, ok := result["references"]
+	assert.Assert(t, ok, "should have parameter references")
+
+	referenceSlice, ok := references.([]interface{})
+	assert.Assert(t, ok, "references should be slice")
+
+	assert.Equal(t, len(referenceSlice), 2)
+	for i, testRef := range []interface{}{testRef1, testRef2} {
+		assert.Equal(t, referenceSlice[i], testRef)
+	}
+}
+
+func TestWriteCompoundParameterErrorOnNonCompoundParameter(t *testing.T) {
+	context := parameter.ParameterWriterContext{Parameter: &value.ValueParameter{}}
+
+	_, err := writeCompoundParameter(context)
+	assert.ErrorContains(t, err, "unexpected type. parameter is not of type `CompoundParameter`")
+}
+
+func TestWriteCompoundParameterErrorOnMissingFormat(t *testing.T) {
+	compoundParameter := CompoundParameter{
+		referencedParameters: []parameter.ParameterReference{
+			parameter.ParameterReference{Property: "firstName"},
+		},
+	}
+	context := parameter.ParameterWriterContext{Parameter: &compoundParameter}
+
+	_, err := writeCompoundParameter(context)
+	assert.ErrorContains(t, err, "missing property `format`")
+}
+
+func TestWriteCompoundParameterErrorOnMissingReferences(t *testing.T) {
+	compoundParameter := CompoundParameter{
+		rawFormatString: "{{ .firstName }} {{ .lastName }}",
+	}
+	context := parameter.ParameterWriterContext{Parameter: &compoundParameter}
+
+	_, err := writeCompoundParameter(context)
+	assert.ErrorContains(t, err, "missing property `references`")
+}


### PR DESCRIPTION
This creates a new parameter type, which is composed of other parameters
within the same config.
This parameter has a value `format`, which specifies a template string
for the actual value of the parameter, and a list of references that are
used by the parameter.

fixes: #394