### PR TITLE
Update downloading-configuration.md

### DIFF
--- a/documentation/versioned_docs/version-1.6.0/commands/downloading-configuration.md
+++ b/documentation/versioned_docs/version-1.6.0/commands/downloading-configuration.md
@@ -24,7 +24,7 @@ Instead of downloading all the configurations for all the API's you can pass a l
 
 ```shell title="shell"
 
-$ monaco download --downloadSpecificAPI alerting-profiles,dashboard --environments=my-environment.yaml
+$ monaco download --downloadSpecificAPI alerting-profile,dashboard --environments=my-environment.yaml
 
 ```
 


### PR DESCRIPTION
On the page https://dynatrace-oss.github.io/dynatrace-monitoring-as-code/configuration/configTypes_tokenPermissions the configuration for the Endpoint /api/config/v1/alertingProfiles is "alerting-profile" and not "alerting-profiles"