### PR TITLE
[WIP] feat(discussion): Start a discussion about config v2 models

### DIFF
--- a/pkg/config/v2/config_persitence.go
+++ b/pkg/config/v2/config_persitence.go
@@ -43,3 +43,41 @@ type topLevelDefinition struct {
 }
 
 type configParameter interface{}
+
+type newTopLevelDefinition struct {
+	Version newConfigDefinitionVersion
+	Configs []newTopLevelConfigDefinition
+}
+
+type newConfigDefinitionVersion string
+const v2 newConfigDefinitionVersion = "v2"
+
+type newTopLevelConfigDefinition struct {
+	Config               newConfigDefinition      				 `yaml:"config"`
+	GroupOverrides       []groupOverride                         `yaml:"groupOverrides,omitempty"`
+	EnvironmentOverrides []environmentOverride                   `yaml:"environmentOverrides,omitempty"`
+}
+
+type newConfigDefinition struct {
+
+	// Either Name or NameFromReference MUST be set
+	// If none is set -> Error
+	// If both are set -> Error
+	Name                 string                                  `yaml:"name,omitempty"`
+	NameFromReference    newConfigParameterDefinition            `yaml:"nameFromReference,omitempty"`
+
+	Parameters           map[string]newConfigParameterDefinition `yaml:"parameters,omitempty"`
+	Template             string                                  `yaml:"template,omitempty"`
+	Skip                 bool                                    `yaml:"skip,omitempty"`
+}
+
+type newConfigParameterDefinition struct {
+	Type     ConfigParameterType `yaml:"type,omitempty"`
+	Property string              `yaml:"property,omitempty"`
+	ConfigId string              `yaml:"config-id,omitempty"`
+	Api      string              `yaml:"api,omitempty"`
+}
+
+type ConfigParameterType string
+const ConfigParameterReference ConfigParameterType = "reference"
+


### PR DESCRIPTION
This commit intends to start a discussion about the model in config v2.
It contains the following changes:

  * Add a version in the top level definition of configs: This helps us
to make changes to the config after the initial release. By not doing
that, we will have a hard time with avoiding backward compatibility
breaking changes. By introducing a version number, we can support
different versions of the config at the same point in time. This helps
us with adding new features and deprecating old ones.

```
version: v2
configs:
- ...
```

  * Remove the config id. The need to specify a config id  seems to me
like an unnecessary hurdle which only makes things more complicated. We
risk that users mistage this for the MeId or ConfigIdentifier coming
back from the Dynatrace APIs. The question here is, if this id is really
necessary?

```
version: v2
configs:
  config:
    name: Federation Availability
```

  * Remove the need of using `interface{}` as the type for
`configDefinition`'s `Name` and `Parameters` properties. Using
`interface{}` as type has the main disadvantage that the config has no
static model anymore - any syntax is valid (as long as its valid yaml).
The user has no possibility to check if the config matches the correct
syntax. That's why this commit aims to split the name and the reference
intwo different properties: `Name` (type: string) and `NameFromReference`
(type: `ConfigParameterType`). One of the two properties needs to be
set:

```
version: v2
configs:
- id: availability
  config:
    name: Federation Availability
    template: availabilty.json
    skip: false
```

```
vrsion: v2
configs:
- id: availability
  config:
    nameFromRference:
        api: management-zone
        config: zone
        property: name
        type: reference
    template: availabilty.json
    skip: false
```

This change makes it possible to add linting / model checking in IDEs
later on.