### PR TITLE
feat(workflow): Add workflow for generating bill-of-materials

### DIFF
--- a/.dependencies/templates/dependencies.csv.tmpl
+++ b/.dependencies/templates/dependencies.csv.tmpl
@@ -1,0 +1,11 @@
+{{- define "depRow" -}}
+{{- range $i, $dep := . }}
+{{ $dep.Name }},{{ $dep.Version }},{{ $dep.LicenceType }}
+{{- end }}
+{{- end -}}
+
+{{ template "depRow" .Direct  }}
+
+{{ if .Indirect }}
+{{ template "depRow" .Indirect  }}
+{{ end }}

--- a/.github/workflows/dependencies-and-licenses.yml
+++ b/.github/workflows/dependencies-and-licenses.yml
@@ -1,0 +1,48 @@
+name: Dependencies and Licenses
+on:
+    workflow_dispatch:
+defaults:
+    run:
+        shell: bash
+jobs:
+    generate-dependencies:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout Core Repo
+              uses: actions/checkout@v2.4.0
+              with:
+                  path: 'dynatrace-oss/dynatrace-monitoring-as-code'
+            - name: Set up Go
+              uses: actions/setup-go@v2
+              with:
+                  go-version: 1.16
+            - name: Install go-licence-detector
+              run: |
+                  go get go.elastic.co/go-licence-detector
+            - name: Set up Node
+              uses: actions/setup-node@v2.4.1
+              with:
+                  node-version: 14
+            - name: Install npm libs
+              run: |
+                  yarn global add license-report
+            - name: GO dependencies and licenses
+              run: |
+                  TMP_DIR=$(mktemp -d 2>/dev/null)
+                  ( cd dynatrace-oss/dynatrace-monitoring-as-code || return ; go mod tidy > /dev/null 2>&1; go list -m -json all | go-licence-detector -depsTemplate=.dependencies/templates/dependencies.csv.tmpl -depsOut="${TMP_DIR}"/dependencies.txt )
+                  cat "$TMP_DIR"/*.txt | sort | uniq > dependencies-and-licenses-go.txt
+                  echo
+                  echo "👍 done. written results to ./dependencies-and-licenses-go.txt"
+                  cat dependencies-and-licenses-go.txt
+            - name: Node dependencies and licenses
+              run: |
+                  echo "🔍 Analyzing dependencies in documentation"
+                  ( cd dynatrace-oss/dynatrace-monitoring-as-code/documentation || return ; license-report --only-prod --output=csv > ../../../dependencies-and-licenses-node.txt )
+                  echo
+                  echo "👍 done. written results to ./dependencies-and-licenses-node.txt"
+                  cat dependencies-and-licenses-node.txt
+            - name: Upload dependencies and licenses artifact
+              uses: actions/upload-artifact@v2
+              with:
+                  name: dependencies-and-licenses
+                  path: dependencies-and-licenses-*.txt


### PR DESCRIPTION
This commit adds a workflow for generating the bill of materials for
`monaco` and its dependencies (including the documentation). The
workflow needs to be started manually for now. At a later point in time,
we can run it for every release. But for now: let's keep it simple.

The approach is "borrowed" from `keptn/keptn` :)

fixes #466