### PR TITLE
fix(integration tests): Fix breaking change in SLO api

### DIFF
--- a/cmd/monaco/test-resources/integration-all-configs/project/slo/slo.json
+++ b/cmd/monaco/test-resources/integration-all-configs/project/slo/slo.json
@@ -6,7 +6,7 @@
   "metricNumerator": "builtin:service.errors.server.successCount",
   "metricDenominator": "builtin:service.requestCount.total",
   "evaluationType": "AGGREGATE",
-  "filter": "type(\"HOST\")",
+  "filter": "mzName(\"{{ .mzone }}\"),type(\"HOST\")",
   "target": 95,
   "warning": 97.5,
   "timeframe": "-1d"

--- a/cmd/monaco/test-resources/integration-all-configs/project/slo/slo.yaml
+++ b/cmd/monaco/test-resources/integration-all-configs/project/slo/slo.yaml
@@ -3,3 +3,4 @@ config:
 
 demo_slo:
   - name: "My SLO"
+  - mzone: "/project/management-zone/zone.name"


### PR DESCRIPTION
This commit fixes a breaking change in the SLO api which prevents
storing an SLO config when no management zone is defined by changing the
integration test config used in the all-configs-integration-test.

fixes #484