### PR TITLE
feat(api): Added service detection APIs

### DIFF
--- a/cmd/monaco/test-resources/integration-all-configs/project/service-detection-full-web-request/demorule.json
+++ b/cmd/monaco/test-resources/integration-all-configs/project/service-detection-full-web-request/demorule.json
@@ -1,0 +1,39 @@
+{
+  "type": "FULL_WEB_REQUEST",
+  "managementZones": [],
+  "name": "{{ .name }}",
+  "description": "{{ .name }}",
+  "enabled": {{ .enabled }},
+  "conditions": [
+    {
+      "attributeType": "SERVER_NAME",
+      "compareOperations": [
+        {
+          "type": "EQUALS",
+          "negate": false,
+          "ignoreCase": false,
+          "values": [
+            "demoserver1",
+            "demoserver2"
+          ]
+        }
+      ]
+    },
+    {
+      "attributeType": "URL_PATH",
+      "compareOperations": [
+        {
+          "type": "EXISTS",
+          "negate": false
+        }
+      ]
+    }
+  ],
+  "contextRoot": {
+    "transformations": [],
+    "segmentsToCopyFromUrlPath": 2
+  },
+  "serverName": {
+    "valueOverride": "demoserver"
+  }
+}

--- a/cmd/monaco/test-resources/integration-all-configs/project/service-detection-full-web-request/servicedetectionrules.yaml
+++ b/cmd/monaco/test-resources/integration-all-configs/project/service-detection-full-web-request/servicedetectionrules.yaml
@@ -1,0 +1,6 @@
+config:
+  - demo_rule: "demorule.json"
+  
+demo_rule:
+  - name: "Service detection - Full Web Request Demo Rule"
+  - enabled: "false"

--- a/cmd/monaco/test-resources/integration-all-configs/project/service-detection-full-web-service/demorule.json
+++ b/cmd/monaco/test-resources/integration-all-configs/project/service-detection-full-web-service/demorule.json
@@ -1,0 +1,41 @@
+{
+    "type": "FULL_WEB_SERVICE",
+    "managementZones": [],
+    "name": "{{ .name }}",
+    "description": "REST API example",
+    "enabled": true,
+    "conditions": [
+        {
+            "attributeType": "FRAMEWORK",
+            "compareOperations": [
+                {
+                    "type": "EQUALS",
+                    "negate": false,
+                    "ignoreCase": false,
+                    "values": [
+                        "JERSEY"
+                    ]
+                }
+            ]
+        },
+        {
+            "attributeType": "URL_PATH",
+            "compareOperations": [
+                {
+                    "type": "STARTS_WITH",
+                    "negate": false,
+                    "ignoreCase": false,
+                    "values": [
+                        "/prefix/"
+                    ]
+                }
+            ]
+        }
+    ],
+    "detectAsWebRequestService": true,
+    "webServiceName": null,
+    "webServiceNameSpace": null,
+    "applicationId": null,
+    "contextRoot": null,
+    "serverName": null
+}

--- a/cmd/monaco/test-resources/integration-all-configs/project/service-detection-full-web-service/servicedetectionrules.yaml
+++ b/cmd/monaco/test-resources/integration-all-configs/project/service-detection-full-web-service/servicedetectionrules.yaml
@@ -1,0 +1,5 @@
+config:
+  - demo_rule: "demorule.json"
+
+demo_rule:
+  - name: "Don't detect Jersey as WebService"

--- a/cmd/monaco/test-resources/integration-all-configs/project/service-detection-opaque-web-request/demorule.json
+++ b/cmd/monaco/test-resources/integration-all-configs/project/service-detection-opaque-web-request/demorule.json
@@ -1,0 +1,46 @@
+{
+    "type": "OPAQUE_AND_EXTERNAL_WEB_REQUEST",
+    "name": "{{ .name }}",
+    "description": "REST API example",
+    "enabled": true,
+    "managementZones": [],
+    "conditions": [
+        {
+            "attributeType": "URL_HOST_NAME",
+            "compareOperations": [
+                {
+                    "type": "STRING_CONTAINS",
+                    "ignoreCase": "false",
+                    "values": [
+                        "value1",
+                        "value2"
+                    ]
+                }
+            ]
+        }
+    ],
+    "applicationId": {
+        "valueOverride": "abc"
+    },
+    "contextRoot": {
+        "segmentsToCopyFromUrlPath": 2,
+        "transformations": [
+            {
+                "type": "BEFORE",
+                "delimiter": "/"
+            }
+        ]
+    },
+    "port": {
+        "doNotUseForServiceId": "true"
+    },
+    "publicDomainName": {
+        "copyFromHostName": "true",
+        "transformations": [
+            {
+                "type": "BEFORE",
+                "delimiter": "/"
+            }
+        ]
+    }
+}

--- a/cmd/monaco/test-resources/integration-all-configs/project/service-detection-opaque-web-request/servicedetectionrules.yaml
+++ b/cmd/monaco/test-resources/integration-all-configs/project/service-detection-opaque-web-request/servicedetectionrules.yaml
@@ -1,0 +1,5 @@
+config:
+  - demo_rule: "demorule.json"
+
+demo_rule:
+  - name: "My sample rule"

--- a/cmd/monaco/test-resources/integration-all-configs/project/service-detection-opaque-web-service/demorule.json
+++ b/cmd/monaco/test-resources/integration-all-configs/project/service-detection-opaque-web-service/demorule.json
@@ -1,0 +1,30 @@
+{
+    "type": "OPAQUE_AND_EXTERNAL_WEB_SERVICE",
+    "name": "{{ .name }}",
+    "description": "REST API example",
+    "enabled": true,
+    "detectAsWebRequestService": false,
+    "managementZones": [],
+    "conditions": [
+        {
+            "attributeType": "URL_PATH",
+            "compareOperations": [
+                {
+                    "type": "STRING_CONTAINS",
+                    "invert": "false",
+                    "ignoreCase": "false",
+                    "values": [
+                        "value1",
+                        "value2"
+                    ]
+                }
+            ]
+        }
+    ],
+    "urlPath": {
+        "valueOverride": "abc"
+    },
+    "port": {
+        "doNotUseForServiceId": "true"
+    }
+}

--- a/cmd/monaco/test-resources/integration-all-configs/project/service-detection-opaque-web-service/servicedetectionrules.yaml
+++ b/cmd/monaco/test-resources/integration-all-configs/project/service-detection-opaque-web-service/servicedetectionrules.yaml
@@ -1,0 +1,5 @@
+config:
+  - demo_rule: "demorule.json"
+
+demo_rule:
+  - name: "My sample rule"

--- a/documentation/docs/configuration/configTypes_tokenPermissions.md
+++ b/documentation/docs/configuration/configTypes_tokenPermissions.md
@@ -39,6 +39,10 @@ These are the supported configuration types, their API endpoints and the token p
 | request-attributes              | _/api/config/v1/service/requestAttributes_      | `Read Configuration` & `Capture request data`                                                                       |
 | request-naming-service          | _/api/config/v1/service/requestNaming_          | `Read Configuration` & `Write Configuration`                                                                        |
 | slo                             | _/api/v2/slo_                                   | `Read SLO` & `Write SLOs`                                                                                           |
+| service-detection-full-web-request   | _/api/config/v1/service/detectionRules/FULL_WEB_REQUEST_                 | `Read Configuration` & `Write Configuration`                                          |
+| service-detection-full-web-service   | _/api/config/v1/service/detectionRules/FULL_WEB_SERVICE_                 | `Read Configuration` & `Write Configuration`                                          |
+| service-detection-opaque-web-request | _/api/config/v1/service/detectionRules/OPAQUE_AND_EXTERNAL_WEB_REQUEST_  | `Read Configuration` & `Write Configuration`                                          |
+| service-detection-opaque-web-service | _/api/config/v1/service/detectionRules/OPAQUE_AND_EXTERNAL_WEB_SERVICE_  | `Read Configuration` & `Write Configuration`                                          |
 | synthetic-location              | _/api/v1/synthetic/locations_                   | `Access problem and event feed, metrics, and topology` & `Create and read synthetic monitors, locations, and nodes` |
 | synthetic-monitor               | _/api/v1/synthetic/monitors_                    | `Create and read synthetic monitors, locations, and nodes`                                                          |
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -148,6 +148,19 @@ var apiMap = map[string]apiInput{
 	"failure-detection-rules": {
 		apiPath: "/api/config/v1/service/failureDetection/parameterSelection/rules",
 	},
+
+	"service-detection-full-web-request": {
+		apiPath: "/api/config/v1/service/detectionRules/FULL_WEB_REQUEST",
+	},
+	"service-detection-full-web-service": {
+		apiPath: "/api/config/v1/service/detectionRules/FULL_WEB_SERVICE",
+	},
+	"service-detection-opaque-web-request": {
+		apiPath: "/api/config/v1/service/detectionRules/OPAQUE_AND_EXTERNAL_WEB_REQUEST",
+	},
+	"service-detection-opaque-web-service": {
+		apiPath: "/api/config/v1/service/detectionRules/OPAQUE_AND_EXTERNAL_WEB_SERVICE",
+	},
 }
 
 var standardApiPropertyNameOfGetAllResponse = "values"

--- a/pkg/rest/config_upload.go
+++ b/pkg/rest/config_upload.go
@@ -50,8 +50,8 @@ func upsertDynatraceObject(client *http.Client, fullUrl string, objectName strin
 
 	if isUpdate {
 		path = joinUrl(fullUrl, existingObjectId)
-		// Updating a dashboard requires the ID to be contained in the JSON, so we just add it...
-		if isApiDashboard(theApi) {
+		// Updating a dashboard, or any service detection API requires the ID to be contained in the JSON, so we just add it...
+		if isApiDashboard(theApi) || isAnyServiceDetectionApi(theApi) {
 			tmp := strings.Replace(string(payload), "{", "{\n\"id\":\""+existingObjectId+"\",\n", 1)
 			body = []byte(tmp)
 		}
@@ -209,6 +209,10 @@ func getObjectIdIfAlreadyExists(client *http.Client, api api.Api, url string, ob
 
 func isApiDashboard(api api.Api) bool {
 	return api.GetId() == "dashboard"
+}
+
+func isAnyServiceDetectionApi(api api.Api) bool {
+	return strings.HasPrefix(api.GetId(), "service-detection-")
 }
 
 func getExistingValuesFromEndpoint(client *http.Client, theApi api.Api, url string, apiToken string) (values []api.Value, err error) {


### PR DESCRIPTION
This PR builds on the awesome work of @luislira22 in #449.

It adds 4 new APIs:
  * service-detection-api-full-web-request
    for api endpoint /api/config/v1/service/detectionRules/FULL_WEB_REQUEST
  * service-detection-full-web-service
    for api endpoint /api/config/v1/service/detectionRules/FULL_WEB_SERVICE
  * service-detection-opaque-web-request
    for api endpoint /api/config/v1/service/detectionRules/OPAQUE_AND_EXTERNAL_WEB_REQUEST
  * service-detection-opaque-web-service
    for api endpoint /api/config/v1/service/detectionRules/OPAQUE_AND_EXTERNAL_WEB_SERVICE