### PR TITLE
fix: do not ignore non-successful responses on GET(all) requests

### DIFF
--- a/pkg/rest/config_upload.go
+++ b/pkg/rest/config_upload.go
@@ -222,6 +222,10 @@ func getExistingValuesFromEndpoint(client *http.Client, theApi api.Api, url stri
 		return nil, err
 	}
 
+	if !success(resp) {
+		return nil, fmt.Errorf("Failed to get existing configs for api %s (HTTP %d)!\n    Response was: %s", theApi.GetId(), resp.StatusCode, string(resp.Body))
+	}
+
 	for {
 
 		err, values, objmap := unmarshalJson(theApi, err, resp)


### PR DESCRIPTION
This commit adds additional error handling when getting all the existing
configs for an API. Previously, we did not check the HTTP status code of
the response coming from the API.

fixes #479