### PR TITLE
Feat/handle timing issues

### DIFF
--- a/cmd/monaco/all_configs_integration_test.go
+++ b/cmd/monaco/all_configs_integration_test.go
@@ -37,6 +37,7 @@ func TestIntegrationAllConfigs(t *testing.T) {
 		// This causes a POST for all configs:
 		statusCode := RunImpl([]string{
 			"monaco",
+			"-v",
 			"--environments", allConfigsEnvironmentsFile,
 			allConfigsFolder,
 		}, fs)
@@ -46,6 +47,7 @@ func TestIntegrationAllConfigs(t *testing.T) {
 		// This causes a PUT for all configs:
 		statusCode = RunImpl([]string{
 			"monaco",
+			"-v",
 			"--environments", allConfigsEnvironmentsFile,
 			// Currently there are some APIs for which updating the config does not work. These configs are included in
 			// the project "only-post" (folder ./test-resources/integration-all-configs/only-post)

--- a/cmd/monaco/test-resources/integration-all-configs/project/calculated-metrics-application-mobile/metrics-mobile-app.yaml
+++ b/cmd/monaco/test-resources/integration-all-configs/project/calculated-metrics-application-mobile/metrics-mobile-app.yaml
@@ -6,6 +6,4 @@ speed:
   - appId: "coming from override"
 
 speed.environment1:
-  # temporarily created by hand in the integration test environment
-  # will be fixed in https://github.com/dynatrace-oss/dynatrace-monitoring-as-code/issues/275
-  - appId: "MOBILE_APPLICATION-23395670912B4E78"
+  - appId: "/only-post/application-mobile/mobile-application.id"

--- a/cmd/monaco/test-resources/integration-all-configs/project/synthetic-monitor/availabilty.json
+++ b/cmd/monaco/test-resources/integration-all-configs/project/synthetic-monitor/availabilty.json
@@ -55,5 +55,5 @@
   "managementZones": [
     "{{.managementZoneId}}"
   ],
-  "manuallyAssignedApps": []
+  "manuallyAssignedApps": ["{{ .appId }}"]
 }

--- a/cmd/monaco/test-resources/integration-all-configs/project/synthetic-monitor/synthetic-monitors.yaml
+++ b/cmd/monaco/test-resources/integration-all-configs/project/synthetic-monitor/synthetic-monitors.yaml
@@ -8,6 +8,7 @@ availability:
   - managementZoneId: "/project/management-zone/zone.id"
   - tag: "/project/auto-tag/application-tagging.name"
   - host: "https://www.google.com"
+  - appId: "/project/application/application.id"
 
 browser-test:
   - name: "Borg Availability"

--- a/pkg/rest/client.go
+++ b/pkg/rest/client.go
@@ -162,10 +162,9 @@ func (d *dynatraceClientImpl) ExistsByName(api Api, name string) (exists bool, i
 
 func (d *dynatraceClientImpl) UpsertByName(api Api, name string, payload []byte) (entity DynatraceEntity, err error) {
 
-	fullUrl := api.GetUrlFromEnvironmentUrl(d.environmentUrl)
-
 	if api.GetId() == "extension" {
+		fullUrl := api.GetUrlFromEnvironmentUrl(d.environmentUrl)
 		return uploadExtension(d.client, fullUrl, name, payload, d.token)
 	}
-	return upsertDynatraceObject(d.client, fullUrl, name, api, payload, d.token)
+	return upsertDynatraceObject(d.client, d.environmentUrl, name, api, payload, d.token)
 }

--- a/pkg/rest/config_upload.go
+++ b/pkg/rest/config_upload.go
@@ -65,34 +65,11 @@ func createDynatraceObject(client *http.Client, fullUrl string, objectName strin
 		path += "?position=PREPEND"
 	}
 
-	resp, err := post(client, path, body, apiToken)
+	resp, err := callWithRetryOnKnowTimingIssue(client, post, objectName, path, body, apiToken)
 	if err != nil {
 		return api.DynatraceEntity{}, err
 	}
 
-	// It can happen that the post fails because config needs time to be propagated on all cluster nodes. If the error
-	// constraintViolations":[{"path":"name","message":"X must have a unique name...
-	// is returned, try once again
-	if !success(resp) && strings.Contains(string(resp.Body), "must have a unique name") {
-		// Try again after 5 seconds:
-		util.Log.Warn("\t\tConfig '%s - %s' needs to have a unique name. Waiting for 5 seconds before retry...", configType, objectName)
-		time.Sleep(5 * time.Second)
-		resp, err = post(client, path, body, apiToken)
-
-		if err != nil {
-			return api.DynatraceEntity{}, err
-		}
-	}
-	// It can take longer until request attributes are ready to be used
-	if !success(resp) && strings.Contains(string(resp.Body), "must specify a known request attribute") {
-		util.Log.Warn("\t\tSpecified request attribute not known for %s. Waiting for 10 seconds before retry...", objectName)
-		time.Sleep(10 * time.Second)
-		resp, err = post(client, path, body, apiToken)
-
-		if err != nil {
-			return api.DynatraceEntity{}, err
-		}
-	}
 	if !success(resp) {
 		return api.DynatraceEntity{}, fmt.Errorf("Failed to create DT object %s (HTTP %d)!\n    Response was: %s", objectName, resp.StatusCode, string(resp.Body))
 	}
@@ -154,7 +131,8 @@ func updateDynatraceObject(client *http.Client, fullUrl string, objectName strin
 		tmp := strings.Replace(string(payload), "{", "{\n\"id\":\""+existingObjectId+"\",\n", 1)
 		body = []byte(tmp)
 	}
-	resp, err := put(client, path, body, apiToken)
+
+	resp, err := callWithRetryOnKnowTimingIssue(client, put, objectName, path, body, apiToken)
 
 	if err != nil {
 		return api.DynatraceEntity{}, err
@@ -170,6 +148,82 @@ func updateDynatraceObject(client *http.Client, fullUrl string, objectName strin
 		Name:        objectName,
 		Description: "Updated existing object",
 	}, nil
+}
+
+// callWithRetryOnKnowTimingIssue handles several know cases in which Dynatrace has a slight delay before newly created objects
+// can be used in further configuration. This is a cheap way to allow monaco to work around this, by waiting, then
+// retrying in case of know errors on upload.
+func callWithRetryOnKnowTimingIssue(client *http.Client, restCall sendingRequest, objectName string, path string, body []byte, apiToken string) (Response, error) {
+
+	resp, err := restCall(client, path, body, apiToken)
+
+	if err == nil && success(resp) {
+		return resp, nil
+	}
+
+	// It can take longer until calculated service metrics are ready to be used in SLOs
+	if isCalculatedMetricNotReadyYet(resp) ||
+		// It can take longer until management zones are ready to be used in SLOs
+		isManagementZoneNotReadyYet(resp) ||
+		// It can take longer until Credentials are ready to be used in Synthetic Monitors
+		isCredentialNotReadyYet(resp) ||
+		// It can take some time for configurations to propagate to all cluster nodes - indicated by an incorrect constraint violation error
+		isGeneralDependencyNotReadyYet(resp) {
+
+		return retry(client, restCall, objectName, path, body, apiToken, 3, 5*time.Second)
+	}
+
+	// It can take even longer until request attributes are ready to be used
+	if isRequestAttributeNotYetReady(resp) {
+		return retry(client, restCall, objectName, path, body, apiToken, 3, 10*time.Second)
+	}
+
+	// It can take even longer until applications are ready to be used in synthetic tests
+	if isApplicationNotReadyYet(resp) {
+		return retry(client, restCall, objectName, path, body, apiToken, 5, 15*time.Second)
+	}
+
+	return resp, nil
+}
+
+func retry(client *http.Client, restCall sendingRequest, objectName string, path string, body []byte, apiToken string, maxRetries int, timeout time.Duration) (Response, error) {
+	for i := 0; i < maxRetries; i++ {
+		util.Log.Warn("\t\t\tDependency of config %s was not available. Waiting for %s before retry...", objectName, timeout)
+		time.Sleep(timeout)
+		resp, err := restCall(client, path, body, apiToken)
+		if err == nil && success(resp) {
+			return resp, err
+		}
+	}
+	return Response{}, fmt.Errorf("dependency of config %s was not available after %d retries", objectName, maxRetries)
+}
+
+func isGeneralDependencyNotReadyYet(resp Response) bool {
+	return strings.Contains(string(resp.Body), "must have a unique name")
+}
+
+func isCalculatedMetricNotReadyYet(resp Response) bool {
+	return strings.Contains(string(resp.Body), "Metric selector for numerator is invalid.")
+}
+
+func isRequestAttributeNotYetReady(resp Response) bool {
+	return strings.Contains(string(resp.Body), "must specify a known request attribute")
+}
+
+func isManagementZoneNotReadyYet(resp Response) bool {
+	return strings.Contains(string(resp.Body), "Entity selector is invalid") ||
+		(strings.Contains(string(resp.Body), "SLO validation failed") &&
+			strings.Contains(string(resp.Body), "Management-Zone not found"))
+}
+
+func isApplicationNotReadyYet(resp Response) bool {
+	return strings.Contains(string(resp.Body), "Unknown application(s)")
+}
+
+func isCredentialNotReadyYet(resp Response) bool {
+	s := string(resp.Body)
+	return strings.Contains(s, "credential-vault") &&
+		strings.Contains(s, "was not available")
 }
 
 func joinUrl(urlBase string, path string) string {

--- a/pkg/rest/config_upload.go
+++ b/pkg/rest/config_upload.go
@@ -62,8 +62,8 @@ func createDynatraceObject(client *http.Client, fullUrl string, objectName strin
 	if configType == "app-detection-rule" {
 		path += "?position=PREPEND"
 	}
-	resp, err := post(client, path, body, apiToken)
 
+	resp, err := post(client, path, body, apiToken)
 	if err != nil {
 		return api.DynatraceEntity{}, err
 	}
@@ -95,6 +95,10 @@ func createDynatraceObject(client *http.Client, fullUrl string, objectName strin
 		return api.DynatraceEntity{}, fmt.Errorf("Failed to create DT object %s (HTTP %d)!\n    Response was: %s", objectName, resp.StatusCode, string(resp.Body))
 	}
 
+	return unmarshalResponse(resp, fullUrl, configType, objectName)
+}
+
+func unmarshalResponse(resp Response, fullUrl string, configType string, objectName string) (api.DynatraceEntity, error) {
 	var dtEntity api.DynatraceEntity
 
 	if configType == "synthetic-monitor" || configType == "synthetic-location" {

--- a/pkg/rest/config_upload.go
+++ b/pkg/rest/config_upload.go
@@ -28,7 +28,9 @@ import (
 	"github.com/dynatrace-oss/dynatrace-monitoring-as-code/pkg/util"
 )
 
-func upsertDynatraceObject(client *http.Client, fullUrl string, objectName string, theApi api.Api, payload []byte, apiToken string) (api.DynatraceEntity, error) {
+func upsertDynatraceObject(client *http.Client, environmentUrl string, objectName string, theApi api.Api, payload []byte, apiToken string) (api.DynatraceEntity, error) {
+
+	fullUrl := theApi.GetUrlFromEnvironmentUrl(environmentUrl)
 
 	existingObjectId, err := getObjectIdIfAlreadyExists(client, theApi, fullUrl, objectName, apiToken)
 	if err != nil {

--- a/pkg/rest/request.go
+++ b/pkg/rest/request.go
@@ -34,6 +34,9 @@ type Response struct {
 	Headers    map[string][]string
 }
 
+// function type of put and post requests
+type sendingRequest func(client *http.Client, url string, data []byte, apiToken string) (Response, error)
+
 func get(client *http.Client, url string, apiToken string) (Response, error) {
 	req, err := request(http.MethodGet, url, apiToken)
 

--- a/pkg/rest/version_check.go
+++ b/pkg/rest/version_check.go
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rest
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+type Version struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+func (v *Version) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+type ApiVersionObject struct {
+	Version string `json:"version"`
+}
+
+const versionPath = "/api/v1/config/clusterversion"
+
+func GetDynatraceVersion(client *http.Client, environmentUrl string, apiToken string) (Version, error) {
+	versionUrl := environmentUrl + versionPath
+	resp, err := get(client, versionUrl, apiToken)
+	if err != nil {
+		return Version{}, fmt.Errorf("failed to query version of Dynatrace environment: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return Version{}, fmt.Errorf("failed to query version of Dynatrace environment: (HTTP %v) %v", resp.StatusCode, string(resp.Body))
+	}
+
+	var jsonResp ApiVersionObject
+	if err := json.Unmarshal(resp.Body, &jsonResp); err != nil {
+		return Version{}, fmt.Errorf("failed to parse Dynatrace version JSON: %w", err)
+	}
+
+	return parseVersion(jsonResp.Version)
+}
+
+func MinimumDynatraceVersionReached(expectedMinVersion Version, currentVersion Version) bool {
+	if currentVersion.Major < expectedMinVersion.Major {
+		return false
+	}
+	if currentVersion.Major == expectedMinVersion.Major &&
+		currentVersion.Minor < expectedMinVersion.Minor {
+		return false
+	}
+	if currentVersion.Major == expectedMinVersion.Major &&
+		currentVersion.Minor == expectedMinVersion.Minor &&
+		currentVersion.Patch < expectedMinVersion.Patch {
+		return false
+	}
+	return true
+}
+
+// parseVersion turns a Dynatrace version string in the format MAJOR.MINOR.PATCH.DATE into a Version object
+// for the version check purposes of monaco the build date part is ignored, assuming correct semantic versioning and
+// not needing to check anything but >= feature versions for our compatibility usecases
+func parseVersion(versionString string) (version Version, err error) {
+	split := strings.Split(versionString, ".")
+	if len(split) != 4 {
+		return version, fmt.Errorf("failed to parse Dynatrace version: format did not meet expected MAJOR.MINOR.PATCH.DATE pattern: %v", versionString)
+	}
+
+	version.Major, err = strconv.Atoi(split[0])
+	if err != nil {
+		return version, fmt.Errorf("failed to parse Dynatrace version: major %v is not a number", split[0])
+	}
+	version.Minor, err = strconv.Atoi(split[1])
+	if err != nil {
+		return version, fmt.Errorf("failed to parse Dynatrace version: minor %v is not a number", split[1])
+	}
+	version.Patch, err = strconv.Atoi(split[2])
+	if err != nil {
+		return version, fmt.Errorf("failed to parse Dynatrace version: patch %v is not a number", split[2])
+	}
+
+	return
+}

--- a/pkg/rest/version_check_test.go
+++ b/pkg/rest/version_check_test.go
@@ -1,0 +1,235 @@
+//go:build unit
+// +build unit
+
+/**
+ * @license
+ * Copyright 2020 Dynatrace LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestGetDynatraceVersion(t *testing.T) {
+	tests := []struct {
+		name           string
+		serverResponse string
+		want           Version
+		wantErr        bool
+	}{
+		{
+			"GetDynatraceVersion_AsExpected_1",
+			`{ "version": "1.236.0.20220203-192004" }`,
+			Version{1, 236, 0},
+			false,
+		},
+		{
+			"GetDynatraceVersion_AsExpected_2",
+			`{ "version": "1.236.5.20220203-192004" }`,
+			Version{1, 236, 5},
+			false,
+		},
+		{
+			"GetDynatraceVersion_AsExpected_3",
+			`{ "version": "2.234.0.20220203-192004" }`,
+			Version{2, 234, 0},
+			false,
+		},
+		{
+			"GetDynatraceVersion_FailOnIncompleteVersionString",
+			`{ "version": "236.0.20220203-192004" }`,
+			Version{},
+			true,
+		},
+		{
+			"GetDynatraceVersion_FailOnInvalidVersionString",
+			`{ "version": "hello.236.0.20220203-192004 }"`,
+			Version{},
+			true,
+		},
+		{
+			"GetDynatraceVersion_IgnoreUnknownJsonProperties",
+			`{ "version": "1.236.0.20220203-192004", "thing": "some" }`,
+			Version{1, 236, 0},
+			false,
+		},
+		{
+			"GetDynatraceVersion_FailOnIncompleteJsonResponse",
+			`{ "version": "1.236.0.20220203-192004" `,
+			Version{},
+			true,
+		},
+		{
+			"GetDynatraceVersion_FailOnUnexpectedJsonResponse_1",
+			`{ "1.236.0.20220203-192004" }"`,
+			Version{},
+			true,
+		},
+		{
+			"GetDynatraceVersion_FailOnUnexpectedJsonResponse_2",
+			`{ "version": { "major": 1, "minor": 236, "patch": 0 } }`,
+			Version{},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				rw.Write([]byte(tt.serverResponse))
+			}))
+			defer server.Close()
+
+			got, err := GetDynatraceVersion(server.Client(), server.URL, "token")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetDynatraceVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetDynatraceVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+func TestMinimumDynatraceVersionReached(t *testing.T) {
+	tests := []struct {
+		expectedMinVersion Version
+		currentVersion     Version
+		want               bool
+	}{
+		{
+			Version{1, 236, 0},
+			Version{1, 234, 0},
+			false,
+		},
+		{
+			Version{1, 236, 0},
+			Version{1, 236, 5},
+			true,
+		},
+		{
+			Version{1, 236, 0},
+			Version{2, 234, 0},
+			true,
+		},
+		{
+			Version{2, 236, 0},
+			Version{1, 234, 0},
+			false,
+		},
+		{
+			Version{2, 236, 0},
+			Version{2, 234, 75},
+			false,
+		},
+		{
+			Version{1, 236, 0},
+			Version{1, 236, 65},
+			true,
+		},
+		{
+			Version{1, 236, 65},
+			Version{1, 236, 65},
+			true,
+		},
+		{
+			Version{1, 236, 65},
+			Version{1, 236, 0},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		tName := "TestMinimumDynatraceVersionReached(" + tt.expectedMinVersion.String() + "," + tt.currentVersion.String() + ")"
+		t.Run(tName, func(t *testing.T) {
+			if got := MinimumDynatraceVersionReached(tt.expectedMinVersion, tt.currentVersion); got != tt.want {
+				t.Errorf("MinimumDynatraceVersionReached() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_parseVersion(t *testing.T) {
+	tests := []struct {
+		versionString string
+		wantVersion   Version
+		wantErr       bool
+	}{
+		{
+			"1.236.0.20220203-192004",
+			Version{1, 236, 0},
+			false,
+		},
+		{
+			"1.236.5.20220203-192004",
+			Version{1, 236, 5},
+			false,
+		},
+		{
+			"2.234.0.20220203-192004",
+			Version{2, 234, 0},
+			false,
+		},
+		{
+			"1.234.0.20220203-192004",
+			Version{1, 234, 0},
+			false,
+		},
+		{
+			"2.241345.353.20220203-192004",
+			Version{2, 241345, 353},
+			false,
+		},
+		{
+			"236.0.20220203-192004",
+			Version{},
+			true,
+		},
+		{
+			"1.2.236.0.20220203-192004",
+			Version{},
+			true,
+		},
+		{
+			"hello.236.0.20220203-192004",
+			Version{},
+			true,
+		},
+		{
+			"version 42",
+			Version{},
+			true,
+		},
+		{
+			"1.236.0",
+			Version{},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run("parseVersion("+tt.versionString+")", func(t *testing.T) {
+			gotVersion, err := parseVersion(tt.versionString)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotVersion, tt.wantVersion) {
+				t.Errorf("parseVersion() gotVersion = %v, want %v", gotVersion, tt.wantVersion)
+			}
+		})
+	}
+}

--- a/pkg/util/uuid_generator.go
+++ b/pkg/util/uuid_generator.go
@@ -1,0 +1,35 @@
+// @license
+// Copyright 2022 Dynatrace LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	uuidLib "github.com/google/uuid"
+)
+
+// UUID v3 (MD5 hash based) for "dynatrace.com" in the "URL" namespace
+const dynatraceNamespaceUuid = "a2673303-5d44-3a6e-999e-9a9d83487e64"
+
+// GenerateUuidFromName generates a fixed UUID from a given configuration name.
+// This is used when dealing with select Dynatrace APIs that do not/or no longer support unique name properties.
+// As a convention between monaco and such APIs, both monaco and Dynatrace will generate the same name-based UUID
+// using UUID v3 (MD5 hash based) with a "dynatrace.com" URL namespace UUID.
+func GenerateUuidFromName(name string) (string, error) {
+	namespaceUuid, err := uuidLib.Parse(dynatraceNamespaceUuid)
+	if err != nil {
+		return "", err
+	}
+	uuid := uuidLib.NewMD5(namespaceUuid, []byte(name)).String()
+	return uuid, nil
+}

--- a/pkg/util/uuid_generator_test.go
+++ b/pkg/util/uuid_generator_test.go
@@ -1,0 +1,68 @@
+//go:build unit
+// +build unit
+
+// @license
+// Copyright 2022 Dynatrace LLC
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import "testing"
+
+func TestGenerateUuidFromName(t *testing.T) {
+	tests := []struct {
+		givenName  string
+		expectUuid string
+	}{
+		{
+			"an application detection rule",
+			"51f47928-d86a-3cd0-9a2a-b0f04a1c4531",
+		},
+		{
+			"",
+			"c28406e6-ef82-362f-81d2-2da0825d64f7",
+		},
+		{
+			"żółć",
+			"fd5c1daa-6c2f-3ee1-a64d-a53df5ba7377",
+		},
+		{
+			"abc",
+			"4e198774-f86e-39ca-85ec-ac8d98a54468",
+		},
+		{
+			"def",
+			"3b55a233-aed8-3cc8-a487-7d35aaad1400",
+		},
+		{
+			"94E6C9827A29E34D78B699D8D9D0D221",
+			"41598cc6-677f-39a0-a8e8-dece5e4e27fc",
+		},
+		{
+			"öööÄüüäÜÜÖÖÖÖ",
+			"59726ed6-0bd1-35cc-8471-86d3dc44105f",
+		},
+	}
+	for _, tt := range tests {
+		t.Run("GenerateUuidFromName("+tt.givenName+")", func(t *testing.T) {
+			gotUuid, err := GenerateUuidFromName(tt.givenName)
+			if err != nil {
+				t.Errorf("GenerateUuidFromName() error = %v", err)
+				return
+			}
+			if gotUuid != tt.expectUuid {
+				t.Errorf("GenerateUuidFromName() gotUuid = %v, want %v", gotUuid, tt.expectUuid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This includes refactorings and some preparatory work from https://github.com/dynatrace-oss/dynatrace-monitoring-as-code/pull/532, but removed the app-detection change until further internal discussion of the API. 

This fixes: 
* #349 
* partially #275 (stripping create-only) - additional required update properties can either be checked in the API doc, or should be returned in a better API error response tbh