### PR TITLE
Improve error messages for YAML conversion issues

### DIFF
--- a/pkg/util/parse.go
+++ b/pkg/util/parse.go
@@ -17,7 +17,7 @@
 package util
 
 import (
-	"errors"
+	"fmt"
 	"os"
 	"regexp"
 	"strings"
@@ -78,7 +78,6 @@ func putOrGet(m map[string]map[string]string, key string) map[string]string {
 func convert(original map[string]interface{}) (err error, typed map[string]map[string]string) {
 
 	m2 := make(map[string]map[string]string)
-	err = errors.New("cannot convert YAML")
 
 	for k1, v1 := range original {
 		switch v2 := v1.(type) {
@@ -98,18 +97,18 @@ func convert(original map[string]interface{}) (err error, typed map[string]map[s
 									m2Inner[k3] = v3
 								}
 							default:
-								return err, m2
+								return fmt.Errorf("cannot convert YAML on level 4: value of key '%s' has unexpected type", k3), m2
 							}
 						default:
-							return err, m2
+							return fmt.Errorf("cannot convert YAML on level 3: invalid key type '%s'", k3), m2
 						}
 					}
 				default:
-					return err, m2
+					return fmt.Errorf("cannot convert YAML on level 2: %s", v3), m2
 				}
 			}
 		default:
-			return err, m2
+			return fmt.Errorf("cannot convert YAML on level 1: value of key '%s' has unexpected type", k1), m2
 		}
 	}
 	return nil, m2

--- a/pkg/util/parse_test.go
+++ b/pkg/util/parse_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"testing"
 
+	"gopkg.in/yaml.v2"
 	"gotest.tools/assert"
 )
 
@@ -147,4 +148,73 @@ func TestReplaceEnvVarWhenVarIsNotPresent(t *testing.T) {
 
 	err, _ := UnmarshalYaml(yamlTestEnvVar, "test-yaml-test-env-var")
 	assert.ErrorContains(t, err, "map has no entry for key \"TEST_ENV_VAR\"")
+}
+
+const testYamlParsingIssueOnLevel1 = `
+light: dark
+`
+
+func TestUnmarshalConvertYamlHasParsingIssuesOnLevel1(t *testing.T) {
+	// Given
+	m := make(map[string]interface{})
+	yaml.Unmarshal([]byte(testYamlParsingIssueOnLevel1), &m)
+
+	// When
+	e, _ := convert(m)
+
+	// Then
+	assert.ErrorContains(t, e, "cannot convert YAML")
+}
+
+const testYamlParsingIssueOnLevel2 = `
+light:
+ - test
+   - test2
+`
+
+func TestUnmarshalConvertYamlHasParsingIssuesOnLevel2(t *testing.T) {
+	// Given
+	m := make(map[string]interface{})
+	yaml.Unmarshal([]byte(testYamlParsingIssueOnLevel2), &m)
+
+	// When
+	e, _ := convert(m)
+
+	// Then
+	assert.ErrorContains(t, e, "cannot convert YAML")
+}
+
+const testYamlParsingIssueOnLevel3 = `
+light:
+ - 123: test2
+`
+
+func TestUnmarshalConvertYamlHasParsingIssuesOnLevel3(t *testing.T) {
+	// Given
+	m := make(map[string]interface{})
+	yaml.Unmarshal([]byte(testYamlParsingIssueOnLevel3), &m)
+
+	// When
+	e, _ := convert(m)
+
+	// Then
+	assert.ErrorContains(t, e, "cannot convert YAML")
+}
+
+const testYamlParsingIssueOnLevel4 = `
+light:
+    - Han:
+       - test
+`
+
+func TestUnmarshalConvertYamlHasParsingIssuesOnLevel4(t *testing.T) {
+	// Given
+	m := make(map[string]interface{})
+	yaml.Unmarshal([]byte(testYamlParsingIssueOnLevel4), &m)
+
+	// When
+	e, _ := convert(m)
+
+	// Then
+	assert.ErrorContains(t, e, "cannot convert YAML")
 }

--- a/pkg/util/parse_test.go
+++ b/pkg/util/parse_test.go
@@ -163,7 +163,7 @@ func TestUnmarshalConvertYamlHasParsingIssuesOnLevel1(t *testing.T) {
 	e, _ := convert(m)
 
 	// Then
-	assert.ErrorContains(t, e, "cannot convert YAML")
+	assert.ErrorContains(t, e, "cannot convert YAML on level 1: value of key 'light' has unexpected type")
 }
 
 const testYamlParsingIssueOnLevel2 = `
@@ -181,7 +181,7 @@ func TestUnmarshalConvertYamlHasParsingIssuesOnLevel2(t *testing.T) {
 	e, _ := convert(m)
 
 	// Then
-	assert.ErrorContains(t, e, "cannot convert YAML")
+	assert.ErrorContains(t, e, "cannot convert YAML on level 2: test - test2")
 }
 
 const testYamlParsingIssueOnLevel3 = `
@@ -198,7 +198,7 @@ func TestUnmarshalConvertYamlHasParsingIssuesOnLevel3(t *testing.T) {
 	e, _ := convert(m)
 
 	// Then
-	assert.ErrorContains(t, e, "cannot convert YAML")
+	assert.ErrorContains(t, e, "cannot convert YAML on level 3: invalid key type '%!s(int=123)'")
 }
 
 const testYamlParsingIssueOnLevel4 = `
@@ -216,5 +216,5 @@ func TestUnmarshalConvertYamlHasParsingIssuesOnLevel4(t *testing.T) {
 	e, _ := convert(m)
 
 	// Then
-	assert.ErrorContains(t, e, "cannot convert YAML")
+	assert.ErrorContains(t, e, "cannot convert YAML on level 4: value of key 'Han' has unexpected type")
 }


### PR DESCRIPTION
## Please review commit by commit

---

`cannot convert YAML` doesn't give any helpful clue. It would be best to print even more details, like: show the YAML along with some visual guide that shows what's wrong along with line number, but I think these messages make troubleshooting way easier already. In this place in the code we don't have access to the line number without a major refactoring.

----

# Testing
Checked end to end on a real-world case where a file was malformed like this:

```
EmailControl-SESemailbouncelist:
  - name: EmailControl - SES email bounce list
  - token : {{.Env.DEV_EMAIL_CONTROL_TOKEN}} #the access token is common for dev/sandbox/sprint
```

The value of `token` should be put in double quotes.

The result:
```
$ /home/piotr/repos/dynatrace-monitoring-as-code/bin/monaco --environments environments.yaml --specific-env
ironment dev
You are currently using the old CLI structure which will be used by
default until monaco version 2.0.0

Check out the beta of the new CLI by adding the environment variable
  "NEW_CLI".

We can't wait for your feedback.

2022-02-24 13:39:38 INFO  Dynatrace Monitoring as Code v1.7.0
2022-02-24 13:39:38 FATAL YAML file general/synthetic-monitor/synthetic-monitor.yaml could not be parsed: cannot convert YAML on level 4: value of key 'token' has unexpected type
```