### PR TITLE
feat(workflow): Add CODEOWNERS default reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# This file is used to assign reviewers to PRs based on ownerships
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Per default maintainer review is requested
+* @dynatrace-oss/mac-maintainers
+
+# doc-owners review documentation/ and any markdown file
+documentation/** @dynatrace-oss/mac-doc-owners
+*.md @dynatrace-oss/mac-doc-owners
+*.MD @dynatrace-oss/mac-doc-owners


### PR DESCRIPTION
Configure ownership of documentation to mac-doc-owners group.

This initial ownership concept should make maintaining documentation easier by enabling more/dedicated people to review and merge changes