### PR TITLE
docs: update macos download url

### DIFF
--- a/documentation/versioned_docs/version-1.7.0/Get-started/installation.md
+++ b/documentation/versioned_docs/version-1.7.0/Get-started/installation.md
@@ -40,7 +40,7 @@ For Linux/macOS, we recommend using `curl`. You can download it from [here](http
  curl -L https://github.com/dynatrace-oss/dynatrace-monitoring-as-code/releases/download/v1.7.0/monaco-linux-386 -o monaco
 
 # macOS
- curl -L https://github.com/dynatrace-oss/dynatrace-monitoring-as-code/releases/download/v1.7.0/monaco-darwin-10.12-amd64 -o monaco
+ curl -L https://github.com/dynatrace-oss/dynatrace-monitoring-as-code/releases/download/v1.7.0/monaco-darwin-10.16-amd64 -o monaco
 ```
 
 Make the binary executable:

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -1,0 +1,8 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -1,8 +1,0 @@
-{
-	"folders": [
-		{
-			"path": "."
-		}
-	],
-	"settings": {}
-}


### PR DESCRIPTION
curl invalid for macos 