### PR TITLE
ci: Build static monaco binary

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Build
         run: make build
 
+      - name: Build release-builds
+        run: make build-release
+
       - name: Unit Test
         run: make test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,21 +25,9 @@ jobs:
           CODE_VERSION=`grep "const MonitoringAsCode" pkg/version/version.go | awk -F"[\"\"]" '{print $2}'`
           TAG_VERSION_WITH_PREFIX=${{ github.ref }}
           [ $CODE_VERSION = ${TAG_VERSION_WITH_PREFIX:11} ];
-      - name: Build
-        run: make build
 
-      - name: Build with xgo
-        uses: crazy-max/ghaction-xgo@v2.1.0
-        with:
-          xgo_version: latest
-          go_version: 1.16.15
-          dest: build
-          prefix: monaco
-          targets: windows/386,windows/amd64,linux/386,linux/amd64,darwin/amd64,darwin/arm64
-          v: true
-          x: false
-          pkg: cmd/monaco
-          ldflags: -s -w
+      - name: Build
+        run: make build-release
 
       - name: Create Release
         uses: actions/create-release@v1.1.4

--- a/Makefile
+++ b/Makefile
@@ -33,18 +33,27 @@ build: clean lint
 	@go build ./...
 	@go build -o ./bin/${BINARY} ./cmd/monaco
 
+build-release: clean lint
+	@echo Release build ${BINARY}
+	@ GOOS=windows GOARCH=amd64 go build -o ./build/${BINARY}-windows-amd64.exe ./cmd/monaco
+	@ GOOS=windows GOARCH=386   go build -o ./build/${BINARY}-windows-386.exe   ./cmd/monaco
+	@ GOOS=linux   GOARCH=amd64 go build -o ./build/${BINARY}-linux-amd64       ./cmd/monaco
+	@ GOOS=linux   GOARCH=386   go build -o ./build/${BINARY}-linux-386         ./cmd/monaco
+	@ GOOS=darwin  GOARCH=amd64 go build -o ./build/${BINARY}-darwin-amd64      ./cmd/monaco
+	@ GOOS=darwin  GOARCH=arm64 go build -o ./build/${BINARY}-darwin-arm64      ./cmd/monaco
+
 install: clean lint
 	@echo Install ${BINARY}
 	@go install ./...
 
 clean:
-	@echo Remove ${BINARY} and bin/
+	@echo Remove bin/ and build/
 ifeq ($(OS),Windows_NT)
-	@if exist ${BINARY} del /Q ${BINARY}
 	@if exist bin rd /S /Q bin
+	@if exist bin rd /S /Q build
 else
-	@rm -f ${BINARY}
 	@rm -rf bin/
+	@rm -rf build/
 endif
 
 test: mocks build

--- a/Makefile
+++ b/Makefile
@@ -35,12 +35,12 @@ build: clean lint
 
 build-release: clean lint
 	@echo Release build ${BINARY}
-	@ GOOS=windows GOARCH=amd64 go build -o ./build/${BINARY}-windows-amd64.exe ./cmd/monaco
-	@ GOOS=windows GOARCH=386   go build -o ./build/${BINARY}-windows-386.exe   ./cmd/monaco
-	@ GOOS=linux   GOARCH=amd64 go build -o ./build/${BINARY}-linux-amd64       ./cmd/monaco
-	@ GOOS=linux   GOARCH=386   go build -o ./build/${BINARY}-linux-386         ./cmd/monaco
-	@ GOOS=darwin  GOARCH=amd64 go build -o ./build/${BINARY}-darwin-amd64      ./cmd/monaco
-	@ GOOS=darwin  GOARCH=arm64 go build -o ./build/${BINARY}-darwin-arm64      ./cmd/monaco
+	@ GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -tags netgo -ldflags '-w -extldflags "-static"' -o ./build/${BINARY}-windows-amd64.exe ./cmd/monaco
+	@ GOOS=windows GOARCH=386   CGO_ENABLED=0 go build -tags netgo -ldflags '-w -extldflags "-static"' -o ./build/${BINARY}-windows-386.exe   ./cmd/monaco
+	@ GOOS=linux   GOARCH=amd64 CGO_ENABLED=0 go build -tags netgo -ldflags '-w -extldflags "-static"' -o ./build/${BINARY}-linux-amd64       ./cmd/monaco
+	@ GOOS=linux   GOARCH=386   CGO_ENABLED=0 go build -tags netgo -ldflags '-w -extldflags "-static"' -o ./build/${BINARY}-linux-386         ./cmd/monaco
+	@ GOOS=darwin  GOARCH=amd64 CGO_ENABLED=0 go build -tags netgo -ldflags '-w -extldflags "-static"' -o ./build/${BINARY}-darwin-amd64      ./cmd/monaco
+	@ GOOS=darwin  GOARCH=arm64 CGO_ENABLED=0 go build -tags netgo -ldflags '-w -extldflags "-static"' -o ./build/${BINARY}-darwin-arm64      ./cmd/monaco
 
 install: clean lint
 	@echo Install ${BINARY}


### PR DESCRIPTION
In order to be libc agnostic, monaco is now build as a static binary.

fix #567