### PR TITLE
fix: do not ignore vars that have "=" in their value

### DIFF
--- a/pkg/util/template.go
+++ b/pkg/util/template.go
@@ -100,7 +100,7 @@ func addEnvVars(properties map[string]string) map[string]interface{} {
 	data["Env"] = envVars
 
 	for _, v := range os.Environ() {
-		split := strings.Split(v, "=")
+		split := strings.SplitN(v, "=", 2)
 		if len(split) != 2 {
 			continue
 		}

--- a/pkg/util/template_test.go
+++ b/pkg/util/template_test.go
@@ -76,6 +76,19 @@ func TestGetStringWithEnvVarAndProperty(t *testing.T) {
 	assert.Equal(t, "Follow the white rabbit", result)
 }
 
+func TestGetStringWithEnvVarIncludingEqualSigns(t *testing.T) {
+
+	template, err := NewTemplateFromString("template_test", testMatrixTemplateWithEnvVar)
+	assert.NilError(t, err)
+
+	SetEnv(t, "ANIMAL", "cow=rabbit=chicken")
+	result, err := template.ExecuteTemplate(getTemplateTestProperties())
+	UnsetEnv(t, "ANIMAL")
+
+	assert.NilError(t, err)
+	assert.Equal(t, "Follow the white cow=rabbit=chicken", result)
+}
+
 func getTemplateTestProperties() map[string]string {
 
 	m := make(map[string]string)


### PR DESCRIPTION
In some cases the value of an environment variable may have an equal sign (for example, within an URL).
Do not try to split in more than two parts.