### PR TITLE
fix(download): Correct debug logging of config being downloaded

### DIFF
--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -209,7 +209,7 @@ func createConfigsFromAPI(
 		return err
 	}
 	for _, val := range values {
-		util.Log.Debug("getting detail %s", val)
+		util.Log.Debug("getting detail %v (%v)", val.Name, val.Id)
 		cont++
 		util.Log.Debug("REQUEST counter %v", cont)
 		name, cleanName, filter, err := jcreator.CreateJSONConfig(fs, client, api, val, subPath)


### PR DESCRIPTION
Rather than trying to log the Value object as a string, when logging that a config is downloaded, log the name and id.

ref: #179