### PR TITLE
fix: download-creates-folders-for-empty-configurations

### DIFF
--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -282,7 +282,6 @@ func createConfigsFromAPI(
 
 		// At this point all API specific substitutions are made (e.g. reports name = dashboard id)
 
-
 		filter, err := jcreator.CreateJSONConfig(fs, client, api, val.Id, jsonConfigFilePath)
 		if err != nil {
 			util.Log.Error("error creating config api json file: %v", err)
@@ -304,10 +303,10 @@ func createConfigsFromAPI(
 		}
 	} else {
 		err = ycreator.WriteYamlFile(fs, subPath, apiId)
-	        if err != nil {
-		        util.Log.Error("error creating config api yaml file: %v", err)
-		        return err
-                }
+		if err != nil {
+			util.Log.Error("error creating config api yaml file: %v", err)
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
monaco download will create an empty synthetic-locations config folder, if only PUBLIC locations exist.

after downloading an api it checks, wether it is empty and deletes deletes the folder if needed

fixes: #666 