### PR TITLE
feat: Improve some log messages

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -213,7 +213,7 @@ func (c *configImpl) GetObjectNameForEnvironment(environment environment.Environ
 		name = c.properties[c.id]["name"]
 	}
 	if name == "" {
-		return "", fmt.Errorf("could not find name property in config %s, please make sure `name` is defined", c.GetFullQualifiedId())
+		return "", fmt.Errorf("could not find name property in config %s, please make sure `name` is defined and not empty", c.GetFullQualifiedId())
 	}
 	if isDependency(name) {
 		return c.parseDependency(name, dict)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -324,7 +324,7 @@ func TestGetObjectNameForEnvironment(t *testing.T) {
 	delete(m["test"], "name")
 	productionResult, err = config.GetObjectNameForEnvironment(testProductionEnvironment, make(map[string]api.DynatraceEntity))
 
-	expected := util.ReplacePathSeparators("could not find name property in config testproject/management-zone/test, please make sure `name` is defined")
+	expected := util.ReplacePathSeparators("could not find name property in config testproject/management-zone/test, please make sure `name` is defined and not empty")
 	assert.Error(t, err, expected)
 }
 

--- a/pkg/rest/config_upload.go
+++ b/pkg/rest/config_upload.go
@@ -324,7 +324,7 @@ func getObjectIdIfAlreadyExists(client *http.Client, api api.Api, url string, ob
 	}
 
 	if configsFound > 1 {
-		util.Log.Error("\t\t\tFound %d configs with same name: %s. Please delete duplicates.", configsFound, objectName)
+		util.Log.Warn("\t\t\tFound %d configs with same name: %s. Please delete duplicates.", configsFound, objectName)
 	}
 	return configName, nil
 }


### PR DESCRIPTION
GetObjectNameForEnvironment: Make it clear to the users that defining the property is not enough, but that it has to be non-empty as well
getObjectIdIfAlreadyExists: Log the Error as a warning as the upload does not end in an error.

Signed-off-by: David Laubreiter <david.laubreiter@dynatrace.com>