### PR TITLE
feat: Allow newlines in variables

### DIFF
--- a/cmd/monaco/test-resources/integration-all-configs/project/dashboard/dashboard.yaml
+++ b/cmd/monaco/test-resources/integration-all-configs/project/dashboard/dashboard.yaml
@@ -3,3 +3,32 @@ config:
 
 dashboard:
   - name: "Alpha Quadrant"
+  - markdown1: |-
+      ## This is a Markdown tile
+
+      It supports **rich text** and [links](https://dynatrace.com)
+
+      It also includes some new-lines to test with. Very cool!
+  - markdown2: "## This is another Markdown tile\n\nTest new-lines with a different approach."
+  - markdown3: "Three tests are better than two.\\n\\nGenerally, the more the merrier."
+  - markdown4: >
+      One more test\n
+      to check if newlines work.
+  - markdown5: Plain string \nusing \\n
+    markdown6: "Line
+      break"
+    markdown7: |
+      One more string
+      With line breaks.
+    markdown8: >-
+      And this one
+    markdown9: >+
+
+      Keep also the useless ones.
+
+    markdown10: |+
+
+      Same here.
+
+
+

--- a/cmd/monaco/test-resources/integration-all-configs/project/dashboard/overview-dashboard.json
+++ b/cmd/monaco/test-resources/integration-all-configs/project/dashboard/overview-dashboard.json
@@ -79,6 +79,48 @@
       },
       "assignedEntities": [],
       "metric": "XHR_ACTIONS"
+    },
+    {
+      "name": "Markdown1",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 342,
+        "left": 380,
+        "width": 304,
+        "height": 152
+      },
+      "nameSize": null,
+      "tileFilter": {},
+      "markdown": "{{ .markdown1 }}"
+    },
+    {
+      "name": "Markdown2",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 494,
+        "left": 380,
+        "width": 304,
+        "height": 152
+      },
+      "nameSize": null,
+      "tileFilter": {},
+      "markdown": "{{ .markdown2 }}"
+    },
+    {
+      "name": "Markdown3",
+      "tileType": "MARKDOWN",
+      "configured": true,
+      "bounds": {
+        "top": 646,
+        "left": 380,
+        "width": 304,
+        "height": 152
+      },
+      "nameSize": null,
+      "tileFilter": {},
+      "markdown": "{{ .markdown3 }}{{ .markdown4 }}{{ .markdown5 }}{{ .markdown6 }}{{ .markdown7 }}{{ .markdown8 }}{{ .markdown9 }}{{ .markdown10 }}"
     }
   ]
 }

--- a/documentation/docs/configuration/yaml_config.md
+++ b/documentation/docs/configuration/yaml_config.md
@@ -240,3 +240,17 @@ of an alerting profile from the env var `ALERTING_PROFILE_VALUE`.
 ```
 
 > :warning: Values you pass into a configuration as environment variables must not contain the `=` character.
+
+### Newlines in variables
+
+All line breaks in variables are escaped.
+
+```yaml
+development:
+    - name: "Dev"
+    - example1: "This is \\n already escaped" 
+    - example2: "This will \n be escaped"
+    - text: |
+        This will also
+        be escaped
+```

--- a/pkg/util/json.go
+++ b/pkg/util/json.go
@@ -82,6 +82,8 @@ func (e *JsonValidationError) PrettyPrintError() {
 			e.LineNumber, lineContent,
 			whiteSpace, whiteSpaceOffset,
 			whiteSpace, e.Cause.Error())
+	} else {
+		Log.Error("\t%v", e)
 	}
 }
 

--- a/pkg/util/template_test.go
+++ b/pkg/util/template_test.go
@@ -108,3 +108,61 @@ func getTemplateTestPropertiesClashingWithEnvVars() map[string]string {
 
 	return m
 }
+
+func TestEscapeNewlineCharacters(t *testing.T) {
+
+	p := map[string]interface{}{
+		"string without newline": "just some string",
+		"string with newline":    "some\nstring",
+		"nested": map[string]interface{}{
+			"nested without newline": "just some string",
+			"nested with newline":    "some\nstring",
+			"deepNested": map[string]interface{}{ // not yet used, but might be in the future
+				"deepNested without newline": "just some string",
+				"deepNested with newline":    "some\nstring",
+			},
+		},
+		"nestedEnv": map[string]string{
+			"nestedEnv without newline": "just some string",
+			"nestedEnv with newline":    "some\nstring",
+		},
+	}
+
+	result := escapeNewlineCharacters(p)
+
+	expected := map[string]interface{}{
+		`string without newline`: `just some string`,
+		`string with newline`:    `some\nstring`,
+		`nested`: map[string]interface{}{
+			`nested without newline`: `just some string`,
+			`nested with newline`:    `some\nstring`,
+			`deepNested`: map[string]interface{}{ // not yet used, but might be in the future
+				`deepNested without newline`: `just some string`,
+				`deepNested with newline`:    `some\nstring`,
+			},
+		},
+		`nestedEnv`: map[string]string{
+			`nestedEnv without newline`: `just some string`,
+			`nestedEnv with newline`:    `some\nstring`,
+		},
+	}
+
+	assert.DeepEqual(t, expected, result)
+}
+
+func TestEscapeNewlineCharactersWithEmptyMap(t *testing.T) {
+
+	empty := map[string]interface{}{}
+
+	assert.DeepEqual(t, escapeNewlineCharacters(empty), empty)
+}
+
+func TestEscapeNewline(t *testing.T) {
+	assert.Equal(t, escapeNewlines("String without newline"), `String without newline`)
+	assert.Equal(t, escapeNewlines("String with one\nnewline"), `String with one\nnewline`)
+	assert.Equal(t, escapeNewlines("String with one windows\r\nnewline"), "String with one windows\r\\nnewline")
+	assert.Equal(t, escapeNewlines("String with already escaped \\n newline"), "String with already escaped \\n newline")
+	assert.Equal(t,
+		escapeNewlines("\nString with multiple \n new\nlines on many positions\n\n"),
+		`\nString with multiple \n new\nlines on many positions\n\n`)
+}


### PR DESCRIPTION
Up to now, it was impossible to use newlines in YAML configurations directly; you had to escape them. 
With this change, it is allowed to use all features yaml gives us to include newlines directly in the yaml variable definition.
Look at the dashboard example for insights on how you can use it.