### PR TITLE
fix(download): Downloading single config Apis now report encountered errors

### DIFF
--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -55,7 +55,7 @@ func getConfigs(fs afero.Fs, workingDir string, environments map[string]environm
 		//download configs for each environment
 		err := downloadConfigFromEnvironment(fs, environment, workingDir, list)
 		if err != nil {
-			util.Log.Error("error while downloading configs for environment %v %v", environment.GetId())
+			util.Log.Error("error while downloading configs for environment %v", environment.GetId())
 			isError = true
 		}
 	}
@@ -141,12 +141,14 @@ func downloadConfigFromEnvironment(fs afero.Fs, environment environment.Environm
 		if isSingleConfigurationApi {
 			errorAPI := createConfigsFromSingleConfigurationAPI(fs, api, path, client, jcreator, ycreator)
 			if errorAPI != nil {
-				util.Log.Error("error getting configs from API %v %v", api.GetId())
+				util.Log.Error("error getting configs from API %v", api.GetId())
+				return errorAPI
 			}
 		} else {
 			errorAPI := createConfigsFromAPI(fs, api, path, client, jcreator, ycreator)
 			if errorAPI != nil {
-				util.Log.Error("error getting configs from API %v %v", api.GetId())
+				util.Log.Error("error getting configs from API %v", api.GetId())
+				return errorAPI
 			}
 		}
 	}

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -39,7 +39,7 @@ func TestGetConfigs(t *testing.T) {
 	fileManager := util.CreateTestFileSystem()
 	envs["e1"] = env
 	err := getConfigs(fileManager, "", envs, "")
-	assert.NilError(t, err)
+	assert.ErrorContains(t, err, "There were some errors")
 }
 
 func TestCreateConfigsFromAPI(t *testing.T) {

--- a/pkg/download/jsoncreator/json_creator.go
+++ b/pkg/download/jsoncreator/json_creator.go
@@ -77,9 +77,10 @@ func (d *JsonCreatorImp) CreateJSONConfig(fs afero.Fs, client rest.DynatraceClie
 
 func getDetailFromAPI(client rest.DynatraceClient, api api.Api, entityId string) (dat map[string]interface{}, filter bool, err error) {
 	escapedEntityId := url.QueryEscape(entityId)
+
 	resp, err := client.ReadById(api, escapedEntityId)
 	if err != nil {
-		util.Log.Error("error getting detail for API %s", api.GetId(), escapedEntityId)
+		util.Log.Error("error getting detail for API %s for entity %v", api.GetId(), escapedEntityId)
 		return nil, false, err
 	}
 

--- a/pkg/rest/client.go
+++ b/pkg/rest/client.go
@@ -18,6 +18,7 @@ package rest
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -154,6 +155,10 @@ func (d *dynatraceClientImpl) ReadById(api Api, id string) (json []byte, err err
 	}
 
 	response, err := get(d.client, url, d.token)
+
+	if !success(response) {
+		return nil, fmt.Errorf("Failed to get existing config for api %v (HTTP %v)!\n    Response was: %v", api.GetId(), response.StatusCode, string(response.Body))
+	}
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fixes #704 

Output w/ -v
```2022-07-28 12:09:57 DEBUG request log not activated
2022-07-28 12:09:57 DEBUG response log not activated
2022-07-28 12:09:57 INFO  Dynatrace Monitoring as Code v1.8.1
2022-07-28 12:09:57 INFO  Creating base project name foo
2022-07-28 12:09:57 WARN  You used an old token format. Please consider switching to the new 1.205+ token format.
2022-07-28 12:09:57 WARN  More information: https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication/#-dynatrace-version-1205--token-format
2022-07-28 12:09:57 INFO   --- GETTING CONFIGS for anomaly-detection-services
2022-07-28 12:09:57 DEBUG No previously downloaded configs found.
2022-07-28 12:09:57 ERROR error getting detail for API anomaly-detection-services for entity anomaly-detection-services
2022-07-28 12:09:57 ERROR error getting detail anomaly-detection-services from API
2022-07-28 12:09:57 ERROR error creating config api json file: Failed to get existing configs for api anomaly-detection-services (HTTP 401)!
    Response was: {"error":{"code":401,"message":"Token Authentication failed"}}
2022-07-28 12:09:57 ERROR error getting configs from API anomaly-detection-services
2022-07-28 12:09:57 ERROR error while downloading configs for environment foo
2022-07-28 12:09:57 ERROR There were some errors while downloading the environment configs, please check the logs
```


