### PR TITLE
fix(download): Deleting configs with slashes in the name does no longer error

### DIFF
--- a/pkg/delete/delete.go
+++ b/pkg/delete/delete.go
@@ -92,11 +92,7 @@ func splitConfigToDelete(config string) (configType string, name string, err err
 		return
 	}
 
-	split := strings.Split(config, "/")
-	if len(split) != 2 {
-		err = errors.New("config " + config + " contains more than one '" + deleteDelimiter + "' delimiter")
-		return
-	}
+	split := strings.SplitN(config, "/", 2)
 
 	return split[0], split[1], nil
 }

--- a/pkg/delete/delete_test.go
+++ b/pkg/delete/delete_test.go
@@ -53,10 +53,40 @@ func TestSplitValidConfigLine(t *testing.T) {
 	assert.Equal(t, "my-dashboard", name)
 }
 
-func TestSplitConfigLineWithTooManyDelimiters(t *testing.T) {
+func TestSplitConfigLineWithTwoDelimiters(t *testing.T) {
 
-	_, _, err := splitConfigToDelete("dashboard/my/dashboard")
-	assert.ErrorContains(t, err, "more than one '/' delimiter")
+	configType, name, err := splitConfigToDelete("dashboard/my/dashboard")
+	assert.NilError(t, err)
+
+	assert.Equal(t, "dashboard", configType)
+	assert.Equal(t, "my/dashboard", name)
+}
+
+func TestSplitConfigLineWithMoreDelimiters(t *testing.T) {
+
+	configType, name, err := splitConfigToDelete("dashboard/my/dashboard/a/s/d/f")
+	assert.NilError(t, err)
+
+	assert.Equal(t, "dashboard", configType)
+	assert.Equal(t, "my/dashboard/a/s/d/f", name)
+}
+
+func TestSplitConfigLineWithTrailingDelimiter(t *testing.T) {
+
+	configType, name, err := splitConfigToDelete("dashboard/my/dashboard/")
+	assert.NilError(t, err)
+
+	assert.Equal(t, "dashboard", configType)
+	assert.Equal(t, "my/dashboard/", name)
+}
+
+func TestSplitConfigLineWithLeadingDelimiter(t *testing.T) {
+
+	configType, name, err := splitConfigToDelete("dashboard//my-dashboard")
+	assert.NilError(t, err)
+
+	assert.Equal(t, "dashboard", configType)
+	assert.Equal(t, "/my-dashboard", name)
 }
 
 func TestSplitConfigLineWithNoDelimiter(t *testing.T) {


### PR DESCRIPTION
With this change, slashes in names are allowed during deletion. The first slash is used to slit between API & name, and all following slashes are ignored.

Tested with the following delete.yaml:
```yaml
delete:
  - conditional-naming-processgroup//a
  - conditional-naming-processgroup/a/b/c/
  - conditional-naming-processgroup/a/b
```

Fixes: #586 