### PR TITLE
feat: allow user-group configuration

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -277,6 +277,10 @@ var apiMap = map[string]apiInput{
 		apiPath:                  "/api/config/v1/geographicRegions/ipAddressMappings",
 		isSingleConfigurationApi: true,
 	},
+	// Early adopter API !
+ 	"user-group": {
+      apiPath: "/api/v1.0/onpremise/groups", 
+  	},
 }
 
 var standardApiPropertyNameOfGetAllResponse = "values"


### PR DESCRIPTION
Allow status check (GET), update (PUT) and creation (POST) of user group, based on Dynatrace Cluster API 1.0 User groups.