### PR TITLE
feat: allow basic user group config

### DIFF
--- a/cmd/monaco/test-resources/integration-all-configs/project/user-group/user-group.json
+++ b/cmd/monaco/test-resources/integration-all-configs/project/user-group/user-group.json
@@ -1,0 +1,45 @@
+{
+    "isClusterAdminGroup": true,
+    "accessAccount": true,
+    "manageAccount": true,
+    "id": null,
+    "name": "{{.name}}",
+    "ldapGroupNames": [
+      "{{.ldapGroupName}}"
+    ],
+    "ssoGroupNames": [
+	"{{.ssoGroupName}}"
+	],
+    "accessRight": {
+      "VIEWER": [
+        "{{.environment-id-VIEWER}}"
+      ],
+      "MANAGE_SETTINGS": [
+        "{{.environment-id-MANAGE-SETTINGS}}"
+      ],
+      "AGENT_INSTALL": [
+        "{{.environment-id-AGENT-INSTALL}}"
+      ],
+      "LOG_VIEWER": [
+        "{{.environment-id-LOG-VIEWER}}"
+      ],
+      "VIEW_SENSITIVE_REQUEST_DATA": [
+        "{{.environment-id-VIEW-SENSITIVE-REQUEST-DATA}}"
+      ],
+      "CONFIGURE_REQUEST_CAPTURE_DATA": [
+        "{{.environment-id-CONFIGURE-REQUEST-CAPTURE-DATA}}"
+      ],
+      "REPLAY_SESSION_DATA": [
+        "{{.environment-id-REPLAY-SESSION-DATA}}"
+      ]
+	  "REPLAY_SESSION_DATA_WITHOUT_MASKING": [
+        "{{.environment-id-REPLAY-SESSION-DATA-WITHOUT-MASKING}}"
+      ],
+      "MANAGE_SECURITY_PROBLEMS": [
+        "{{.environment-id-MANAGE-SECURITY-PROBLEMS}}"
+      ],
+      "MANAGE_SUPPORT_TICKETS": [
+        "{{.environment-id-MANAGE-SUPPORT-TICKETS}}"
+      ]
+	}
+  },

--- a/cmd/monaco/test-resources/integration-all-configs/project/user-group/user-group.yaml
+++ b/cmd/monaco/test-resources/integration-all-configs/project/user-group/user-group.yaml
@@ -1,0 +1,17 @@
+config:
+- user-group: "user-group.json"
+
+user-group:
+- name: "Test-user-group"
+- ldapGroupName: "ldapGroupName1" 
+- ssoGroupName: "ssoGroupName1"
+- environment-id-VIEWER: "environment-id-1"
+- environment-id-MANAGE-SETTINGS: "environment-id-1"
+- environment-id-AGENT-INSTALL: "environment-id-1"
+- environment-id-LOG-VIEWER: "environment-id-1"
+- environment-id-VIEW-SENSITIVE-REQUEST-DATA: "environment-id-1"
+- environment-id-CONFIGURE-REQUEST-CAPTURE-DATA: ""
+- environment-id-REPLAY-SESSION-DATA: "environment-id-1"
+- environment-id-REPLAY-SESSION-DATA-WITHOUT-MASKING: ""
+- environment-id-MANAGE-SECURITY-PROBLEMS: ""
+- environment-id-MANAGE-SUPPORT-TICKETS: ""

--- a/documentation/versioned_docs/version-1.8.1/configuration/configTypes_tokenPermissions.md
+++ b/documentation/versioned_docs/version-1.8.1/configuration/configTypes_tokenPermissions.md
@@ -67,7 +67,7 @@ These are the supported configuration types, their API endpoints and the token p
 | service-resource-naming <br /> **SINGLE CONFIGURATION ENDPOINT**             | _/api/config/v1/service/resourceNaming_                                    | `Read Configuration` & `Write Configuration`                                                                        |
 | synthetic-location                                                           | _/api/v1/synthetic/locations_                                              | `Access problem and event feed, metrics, and topology` & `Create and read synthetic monitors, locations, and nodes` |
 | synthetic-monitor                                                            | _/api/v1/synthetic/monitors_                                               | `Create and read synthetic monitors, locations, and nodes`                                                          |
-| user-group                                                            | _/api/v1/onpremise/groups                                               | `Read, create and update user group`                                                          |
+| user-group                                                            | _/api/v1/onpremise/groups                                               | `Service Provider API`                                                          |
 
 For reference, refer to [this](https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication) page for a detailed
 description to each token permission.

--- a/documentation/versioned_docs/version-1.8.1/configuration/configTypes_tokenPermissions.md
+++ b/documentation/versioned_docs/version-1.8.1/configuration/configTypes_tokenPermissions.md
@@ -67,6 +67,7 @@ These are the supported configuration types, their API endpoints and the token p
 | service-resource-naming <br /> **SINGLE CONFIGURATION ENDPOINT**             | _/api/config/v1/service/resourceNaming_                                    | `Read Configuration` & `Write Configuration`                                                                        |
 | synthetic-location                                                           | _/api/v1/synthetic/locations_                                              | `Access problem and event feed, metrics, and topology` & `Create and read synthetic monitors, locations, and nodes` |
 | synthetic-monitor                                                            | _/api/v1/synthetic/monitors_                                               | `Create and read synthetic monitors, locations, and nodes`                                                          |
+| user-group                                                            | _/api/v1/onpremise/groups                                               | `Read, create and update user group`                                                          |
 
 For reference, refer to [this](https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication) page for a detailed
 description to each token permission.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -277,6 +277,10 @@ var apiMap = map[string]apiInput{
 		apiPath:                  "/api/config/v1/geographicRegions/ipAddressMappings",
 		isSingleConfigurationApi: true,
 	},
+// Early adopter API !
+ "user-group": {
+      apiPath: "/api/v1.0/onpremise/groups", 
+  },
 }
 
 var standardApiPropertyNameOfGetAllResponse = "values"


### PR DESCRIPTION
Create a new API to allow basic user group config to read (GET), create (POST) and update (PUT) user group, based on Dynatrace Cluster API 1.0, as per steps in guideline. Link: https://dynatrace-oss.github.io/dynatrace-monitoring-as-code/Guides/add_new_api/