### PR TITLE
feat: Retry SLO creation on additional know error

### DIFF
--- a/pkg/rest/config_upload.go
+++ b/pkg/rest/config_upload.go
@@ -248,7 +248,8 @@ func isGeneralDependencyNotReadyYet(resp Response) bool {
 }
 
 func isCalculatedMetricNotReadyYet(resp Response) bool {
-	return strings.Contains(string(resp.Body), "Metric selector for numerator is invalid.")
+	return strings.Contains(string(resp.Body), "Metric selector") &&
+		strings.Contains(string(resp.Body), "invalid")
 }
 
 func isRequestAttributeNotYetReady(resp Response) bool {


### PR DESCRIPTION
Similar to the previously known user error message, a general
'Metric selector is invalid' is usually returned while a calculated
metric is not yet available for use in an SLO.

This additional will trigger monaco's retry logic for this message as
well.