### PR TITLE
fix: More leniently handle Dynatrace errors that are ususally caused …

### DIFF
--- a/pkg/rest/config_upload.go
+++ b/pkg/rest/config_upload.go
@@ -264,7 +264,7 @@ func isManagementZoneNotReadyYet(resp Response) bool {
 }
 
 func isApplicationNotReadyYet(resp Response, theApi api.Api) bool {
-	return (theApi.GetId() == "synthetic-monitor" && resp.StatusCode == 500) ||
+	return isServerError(resp) && (theApi.GetId() == "synthetic-monitor" || isAnyApplicationApi(theApi)) ||
 		strings.Contains(string(resp.Body), "Unknown application(s)")
 }
 
@@ -352,6 +352,10 @@ func isReportsApi(api api.Api) bool {
 
 func isAnyServiceDetectionApi(api api.Api) bool {
 	return strings.HasPrefix(api.GetId(), "service-detection-")
+}
+
+func isAnyApplicationApi(api api.Api) bool {
+	return strings.HasPrefix(api.GetId(), "application-")
 }
 
 func isMobileApp(api api.Api) bool {
@@ -551,4 +555,8 @@ func translateSyntheticEntityResponse(resp api.SyntheticEntity, objectName strin
 
 func success(resp Response) bool {
 	return resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated || resp.StatusCode == http.StatusNoContent
+}
+
+func isServerError(resp Response) bool {
+	return resp.StatusCode >= 500 && resp.StatusCode <= 599
 }


### PR DESCRIPTION
…by newly created applications not being found yet

Trigger retries in more general cases of server errors (5xx) being reported for known APIs. Also unit test retry decision logic and related code.