### PR TITLE
fix(docs): Configure all links as relative or absolute from content root

### DIFF
--- a/documentation/docs/Get-started/installation.md
+++ b/documentation/docs/Get-started/installation.md
@@ -153,4 +153,4 @@ GLOBAL OPTIONS:
   </TabItem>
 </Tabs>
 
-Now that Monaco is installed, follow our introductory guide on [how to deploy a configuration to Dynatrace.](../configuration/deploy_configuration)
+Now that Monaco is installed, follow our introductory guide on [how to deploy a configuration to Dynatrace.](/configuration/deploy_configuration.md)

--- a/documentation/docs/Get-started/intro.md
+++ b/documentation/docs/Get-started/intro.md
@@ -37,7 +37,7 @@ Monaco currently offers the following features:
 
 ## Get started
 
-To get started, follow our guide on [how to install Monaco.](./installation)
+To get started, follow our guide on [how to install Monaco.](installation.md)
 
 ## Learn more
 

--- a/documentation/docs/Guides/add_new_api.md
+++ b/documentation/docs/Guides/add_new_api.md
@@ -2,23 +2,23 @@
 sidebar_position: 1
 title: Add a new API
 ---
-​
-This guide shows you how to add a new API to Monaco that is not included in the [table of supported APIs](configuration/configTypes_tokenPermissions.md) and how to determine whether an API is easy to add.
-​
+
+This guide shows you how to add a new API to Monaco that is not included in the [table of supported APIs](/configuration/configTypes_tokenPermissions.md) and how to determine whether an API is easy to add.
+
 > :warning: Adding APIs to Monaco is straightforward in most cases. However, some APIs require more coding.
-​
+
 
 ## Determine if an API is easy to add
-​
+
 Easy-to-add APIs fulfill the following criteria: 
-​
+
 * Configuration APIs that implement the following HTTP methods: 
   * `GET <my-environment>/api/config/v1/<my-config>` (get all configs)
   * `GET <my-environment>/api/config/v1/<my-config>/<id>` (get a single config)
   * `POST <my-environment>/api/config/v1/<my-config>` (create a new config)
   * `PUT <my-environment>/api/config/v1/<my-config>/<id>` (change an existing config)
   * `DELETE <my-environment>/api/config/v1/<my-config>/<id>` (delete a config)
-​
+
 
 * The model of the configuration has a `name` property: 
  
@@ -29,10 +29,10 @@ Easy-to-add APIs fulfill the following criteria:
       ...
 }
 ```
-​
+
 
 * The `GET (all)` REST call return `id` and `name`:
-​
+
 
 ```json
 {
@@ -45,10 +45,10 @@ Easy-to-add APIs fulfill the following criteria:
 }
 ```
 
-​
+
 If your API fulfills these 3 criteria, perform the steps in the following section to add it to Monaco.
 
-​
+
 ## Recognize if an API is of single configuration format
 
 In addition to *easy-to-add* APIs, there are such APIs that comply to a *single configuration* format:
@@ -64,11 +64,11 @@ to get implementation feedback from the maintainers.
 
 
 ## Add a new API to Monaco
-​
+
 Take the following steps to add a new API to Monaco.
 
 1. Open your preferred CLI and enter the following code to add your API to [the map in api.go](https://github.com/dynatrace-oss/dynatrace-monitoring-as-code/blob/main/pkg/api/api.go#L25) and replace the placeholder values as described below. 
-​
+
 
 ```json
   "<my-api-folder-name>": {
@@ -78,7 +78,7 @@ Take the following steps to add a new API to Monaco.
       propertyNameOfGetAllResponse: "<property-name>",         // only necessary if API returns no "values" envelope (see below)
   },
 ```
-​
+
 
 | Placeholder     | Description | 
 | ----------- | ----------- | 
@@ -87,7 +87,7 @@ Take the following steps to add a new API to Monaco.
 | <nobr>`<is-single-configuration-api>`</nobr> | Boolean value specifying if an API is of single configuration format (optional, default: *false*). |
 | <nobr>`<is-non-unique-name-api>`</nobr> | Boolean value specifying if an API doesn't have a unique name attribute (optional, default: *false*). |
 | <nobr>`<property-name>`</nobr> | This names the json property used in the `GET ALL` REST call to return the list of configs. E.g. it would be `extensions`, if the response of your API's `GET ALL` REST call looks like the snippet below|
-​
+
   
 ```json
     {
@@ -103,12 +103,12 @@ Take the following steps to add a new API to Monaco.
       }
 ```
 
-​
+
 2. Add a sample config for the integration tests in [cmd/monaco/test-resources/integration-all-configs](https://github.com/dynatrace-oss/dynatrace-monitoring-as-code/tree/main/cmd/monaco/test-resources/integration-all-configs)
 
-​
-3. Add your API to the [table of supported APIs](../configuration/configTypes_tokenPermissions).
-​
+
+3. Add your API to the [table of supported APIs](/configuration/configTypes_tokenPermissions.md).
+
 > :rocket: After performing these steps, please create the pull request in the upstream repository to share it with the community!
 
 ## Deprecating configuration types
@@ -132,4 +132,4 @@ Deprecated APIs are handled differently. For example, they are not downloaded an
 
 As a rule of thumb, the same configuration types shall be re-used when e.g. new features are added. However, if a feature breaks functionality of an existing configuration type it is usually better to create a new vesion increment and deprecate the previously existing one.
 
-For example, more info about the *dashboard*, *request-naming-service*, *app-detection-rule* deprecation can be found [here](./deprecated_migration).
+For example, more info about the *dashboard*, *request-naming-service*, *app-detection-rule* deprecation can be found [here](deprecated_migration.md).

--- a/documentation/docs/Guides/deprecated_migration.md
+++ b/documentation/docs/Guides/deprecated_migration.md
@@ -2,7 +2,7 @@
 sidebar_position: 2
 title: Migrating deprecated configuration types
 ---
-​
+
 This guide shows you how to migrate deprecated configuration types.
 
 ## *dashboard*, *request-naming-service*, *app-detection-rule*

--- a/documentation/docs/commands/experimental-new-cli.md
+++ b/documentation/docs/commands/experimental-new-cli.md
@@ -21,10 +21,10 @@ NEW_CLI=1 monaco
 
 This command is basically doing what the old tool did. It is used to deploy a specified config to a Dynatrace environment.
 The flags to things like the environments files are mostly the same.
-Read more about it here: [Deploy projects](../commands/deploying-projects.md)
+Read more about it here: [Deploy projects](deploying-projects.md)
 
 ### Download
 
 This command allows you to download the configuration from a Dynatrace tenant as Monaco files.
 Use this command to avoid starting from scratch when using Monaco.
-Read more about it here: [Download configuration](../commands/downloading-configuration.md)
+Read more about it here: [Download configuration](downloading-configuration.md)

--- a/documentation/docs/commands/validating-configuration.md
+++ b/documentation/docs/commands/validating-configuration.md
@@ -16,7 +16,7 @@ monaco --dry-run --environments=environments.yaml
 
 ## Validating your configuration using the new CLI
 
-To validate your configuration [using the new CLI](./experimental-new-cli.md), add the `--dry-run` flag to the `deploy` command.
+To validate your configuration [using the new CLI](experimental-new-cli.md), add the `--dry-run` flag to the `deploy` command.
 ```shell title="Validating your configuration using the new CLI"
 NEW_CLI=1 monaco deploy --dry-run --environments=environments.yaml
 ```

--- a/documentation/docs/configuration/configTypes_tokenPermissions.md
+++ b/documentation/docs/configuration/configTypes_tokenPermissions.md
@@ -74,4 +74,4 @@ These are the supported configuration types, their API endpoints and the token p
 For reference, refer to [this](https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication) page for a detailed
 description to each token permission.
 
-If your desired API is not in the table above, please consider adding it by following the instructions in [How to add new APIs](Guides/add_new_api.md).
+If your desired API is not in the table above, please consider adding it by following the instructions in [How to add new APIs](/Guides/add_new_api.md).

--- a/documentation/docs/configuration/configuration_structure.md
+++ b/documentation/docs/configuration/configuration_structure.md
@@ -27,9 +27,9 @@ Configs can then be downloaded via the respective GET endpoint defined in the Dy
 Checked-in configuration should **not** include:
 
 * The entity's `id` but only its `name`. The entity may be created or updated if one of the same name exists.
-  * The `name` must be defined as [a variable](#configuration-yaml-structure).
+  * The `name` must be defined as [a variable](yaml_config.md#config-yaml-structure).
 * Hardcoded values for environment information such as references to other auto-deployed entities, tags, management-zones, etc.
-  * These should all be referenced as variables as [described below](#referencing-other-configurations).
+  * These should all be referenced as variables as [described here](yaml_config.md#referencing-other-configurations).
 * Empty/null values that are optional for the creation of an object.
   * Most API GET endpoints return more data than needed to create an object. Many of those fields are empty or null and can be omitted.
   * E.g., `tileFilter`s on dashboards
@@ -41,7 +41,7 @@ The tool handles these files as templates, so you can use the following variable
 ```
 
 
-Variables present in the template need to be defined in the respective config`yaml` - [see 'Configuration YAML Structure'](../configuration/yaml_config).
+Variables present in the template need to be defined in the respective config`yaml` - [see 'Configuration YAML Structure'](yaml_config.md).
 
 ### Dashboard JSON
 
@@ -71,9 +71,9 @@ We recommend the following values for the `dashboardMetadata`:
 ```
 
 This config does the following:
-* Reference the name of the Dashboard as a [variable](../configuration/yaml_config)
+* Reference the name of the Dashboard as a [variable](yaml_config.md)
 * Share the dashboard with other users
-* Set a management zone filter on the complete dashboard, again as a variable, most likely [referenced from another config](../configuration/yaml_config#referencing-other-configurations)
+* Set a management zone filter on the complete dashboard, again as a variable, most likely [referenced from another config](yaml_config.md#referencing-other-configurations)
   * Filtering the whole dashboard by management zone makes sure no private data is accidentally picked up on tiles and removes the possible need to define filters for individual tiles
 
 From Dynatrace version 208 onwards:
@@ -151,7 +151,7 @@ And it also applies to the `SERVICE` type.
 ### Configuration types / APIs
 
 Each type of folder must contain one `configuration yaml` and one or more JSON files containing the actual configuration sent to the Dynatrace API.
-The folder name is case-sensitive and needs to be written exactly as in its definition in [Supported configuration types](../configuration/configTypes_tokenPermissions).
+The folder name is case-sensitive and needs to be written exactly as in its definition in [Supported configuration types](configTypes_tokenPermissions.md).
 
 
 ```

--- a/documentation/docs/configuration/deploy_configuration.md
+++ b/documentation/docs/configuration/deploy_configuration.md
@@ -41,7 +41,7 @@ To deploy to one specific environment within an `environments.yaml` file, the `-
 ```shell
 monaco -e=environments.yaml -se=my-environment -p="my-environment" cluster
 ```
-Read more about the environments file here: [Environments file](./environments_file)
+Read more about the environments file here: [Environments file](environments_file.md)
 
 ### Running the tool with a proxy
 

--- a/documentation/docs/configuration/special_config_types.md
+++ b/documentation/docs/configuration/special_config_types.md
@@ -36,6 +36,6 @@ To work around this, special handling is present for these configuration APIS, e
 As this switch from names to IDs results in re-creating configurations if they were previously created by name,
 already existing configuration types like `dashboard` are retained with the previous flawed handling, while new `-v2` configuration types were added with the non-unique-name constraint/handling.
 
-To ensure configurations are correctly updated, please see the manual steps in the [Migration Guide](Guides/deprecated_migration.md) for how to deal with this.
+To ensure configurations are correctly updated, please see the manual steps in the [Migration Guide](/Guides/deprecated_migration.md) for how to deal with this.
 
 > NOTE: As the `-v2` naming implies, the previous handling is deprecated and will be dropped in version 2.0.

--- a/documentation/docs/configuration/yaml_config.md
+++ b/documentation/docs/configuration/yaml_config.md
@@ -37,7 +37,7 @@ profile:
 
 Every config needs to provide a name for unique identification. Omitting the name variable or using a duplicate name causes a validation / deployment error.
 
-Any defined `{config name}` represents a variable that can then be used in a [JSON template](../configuration/configuration_structure#config-json-templates), and will be resolved and inserted into the config before deploying to Dynatrace.
+Any defined `{config name}` represents a variable that can then be used in a [JSON template](configuration_structure.md#config-json-templates), and will be resolved and inserted into the config before deploying to Dynatrace.
 
 Example: `projects/infrastructure/alerting-profile/profiles.yaml` defines a `name`, which is then used in `projects/infrastructure/alerting-profile/profile.json` as `{{.name}}`.
 

--- a/documentation/docs/documentation.md
+++ b/documentation/docs/documentation.md
@@ -29,18 +29,18 @@ Monaco is a "monitoring as code" tool that allows you to create, update and vers
 
   <li>
 
-[What is Monaco?](./Get-started/intro)
+[What is Monaco?](/Get-started/intro.md)
   </li>
 
 <li>
 
-[Install Monaco](./Get-started/installation)
+[Install Monaco](/Get-started/installation.md)
 
 </li>
 
   <li>
 
-[Deploy configuration](./configuration/deploy_configuration)
+[Deploy configuration](/configuration/deploy_configuration.md)
 
   </li>
 
@@ -60,19 +60,19 @@ Monaco is a "monitoring as code" tool that allows you to create, update and vers
 
   <li>
 
-[Delete configuration](./configuration/delete_config)
+[Delete configuration](/configuration/delete_config.md)
 
   </li>
 
   <li>
 
-[Add a new API](./Guides/add_new_api)
+[Add a new API](/Guides/add_new_api.md)
 
   </li>
 
   <li>
 
-[Activate the new CLI](./commands/experimental-new-cli)
+[Activate the new CLI](/commands/experimental-new-cli.md)
 
   </li>
 
@@ -97,7 +97,7 @@ Monaco is a "monitoring as code" tool that allows you to create, update and vers
 
   <li>
 
-[License and bill of materials](./Useful-links/bill-of-materials)  
+[License and bill of materials](/Useful-links/bill-of-materials.md)  
 
   </li>
 

--- a/documentation/versioned_docs/version-1.8.3/Get-started/installation.md
+++ b/documentation/versioned_docs/version-1.8.3/Get-started/installation.md
@@ -153,4 +153,4 @@ GLOBAL OPTIONS:
   </TabItem>
 </Tabs>
 
-Now that Monaco is installed, follow our introductory guide on [how to deploy a configuration to Dynatrace.](../configuration/deploy_configuration)
+Now that Monaco is installed, follow our introductory guide on [how to deploy a configuration to Dynatrace.](/configuration/deploy_configuration.md)

--- a/documentation/versioned_docs/version-1.8.3/Get-started/intro.md
+++ b/documentation/versioned_docs/version-1.8.3/Get-started/intro.md
@@ -37,7 +37,7 @@ Monaco currently offers the following features:
 
 ## Get started
 
-To get started, follow our guide on [how to install Monaco.](./installation)
+To get started, follow our guide on [how to install Monaco.](installation.md)
 
 ## Learn more
 

--- a/documentation/versioned_docs/version-1.8.3/Guides/add_new_api.md
+++ b/documentation/versioned_docs/version-1.8.3/Guides/add_new_api.md
@@ -2,23 +2,23 @@
 sidebar_position: 1
 title: Add a new API
 ---
-​
-This guide shows you how to add a new API to Monaco that is not included in the [table of supported APIs](configuration/configTypes_tokenPermissions.md) and how to determine whether an API is easy to add. 
-​
+
+This guide shows you how to add a new API to Monaco that is not included in the [table of supported APIs](/configuration/configTypes_tokenPermissions.md) and how to determine whether an API is easy to add.
+
 > :warning: Adding APIs to Monaco is straightforward in most cases. However, some APIs require more coding.
-​
+
 
 ## Determine if an API is easy to add
-​
+
 Easy-to-add APIs fulfill the following criteria: 
-​
+
 * Configuration APIs that implement the following HTTP methods: 
   * `GET <my-environment>/api/config/v1/<my-config>` (get all configs)
   * `GET <my-environment>/api/config/v1/<my-config>/<id>` (get a single config)
   * `POST <my-environment>/api/config/v1/<my-config>` (create a new config)
   * `PUT <my-environment>/api/config/v1/<my-config>/<id>` (change an existing config)
   * `DELETE <my-environment>/api/config/v1/<my-config>/<id>` (delete a config)
-​
+
 
 * The model of the configuration has a `name` property: 
  
@@ -29,10 +29,10 @@ Easy-to-add APIs fulfill the following criteria:
       ...
 }
 ```
-​
+
 
 * The `GET (all)` REST call return `id` and `name`:
-​
+
 
 ```json
 {
@@ -45,10 +45,10 @@ Easy-to-add APIs fulfill the following criteria:
 }
 ```
 
-​
+
 If your API fulfills these 3 criteria, perform the steps in the following section to add it to Monaco.
 
-​
+
 ## Recognize if an API is of single configuration format
 
 In addition to *easy-to-add* APIs, there are such APIs that comply to a *single configuration* format:
@@ -64,11 +64,11 @@ to get implementation feedback from the maintainers.
 
 
 ## Add a new API to Monaco
-​
+
 Take the following steps to add a new API to Monaco.
 
 1. Open your preferred CLI and enter the following code to add your API to [the map in api.go](https://github.com/dynatrace-oss/dynatrace-monitoring-as-code/blob/main/pkg/api/api.go#L25) and replace the placeholder values as described below. 
-​
+
 
 ```json
   "<my-api-folder-name>": {
@@ -78,7 +78,7 @@ Take the following steps to add a new API to Monaco.
       propertyNameOfGetAllResponse: "<property-name>",         // only necessary if API returns no "values" envelope (see below)
   },
 ```
-​
+
 
 | Placeholder     | Description | 
 | ----------- | ----------- | 
@@ -87,7 +87,7 @@ Take the following steps to add a new API to Monaco.
 | <nobr>`<is-single-configuration-api>`</nobr> | Boolean value specifying if an API is of single configuration format (optional, default: *false*). |
 | <nobr>`<is-non-unique-name-api>`</nobr> | Boolean value specifying if an API doesn't have a unique name attribute (optional, default: *false*). |
 | <nobr>`<property-name>`</nobr> | This names the json property used in the `GET ALL` REST call to return the list of configs. E.g. it would be `extensions`, if the response of your API's `GET ALL` REST call looks like the snippet below|
-​
+
   
 ```json
     {
@@ -103,12 +103,12 @@ Take the following steps to add a new API to Monaco.
       }
 ```
 
-​
+
 2. Add a sample config for the integration tests in [cmd/monaco/test-resources/integration-all-configs](https://github.com/dynatrace-oss/dynatrace-monitoring-as-code/tree/main/cmd/monaco/test-resources/integration-all-configs)
 
-​
-3. Add your API to the [table of supported APIs](../configuration/configTypes_tokenPermissions).
-​
+
+3. Add your API to the [table of supported APIs](/configuration/configTypes_tokenPermissions.md).
+
 > :rocket: After performing these steps, please create the pull request in the upstream repository to share it with the community!
 
 ## Deprecating configuration types
@@ -132,4 +132,4 @@ Deprecated APIs are handled differently. For example, they are not downloaded an
 
 As a rule of thumb, the same configuration types shall be re-used when e.g. new features are added. However, if a feature breaks functionality of an existing configuration type it is usually better to create a new vesion increment and deprecate the previously existing one.
 
-For example, more info about the *dashboard*, *request-naming-service*, *app-detection-rule* deprecation can be found [here](./deprecated_migration).
+For example, more info about the *dashboard*, *request-naming-service*, *app-detection-rule* deprecation can be found [here](deprecated_migration.md).

--- a/documentation/versioned_docs/version-1.8.3/Guides/deprecated_migration.md
+++ b/documentation/versioned_docs/version-1.8.3/Guides/deprecated_migration.md
@@ -2,7 +2,7 @@
 sidebar_position: 2
 title: Migrating deprecated configuration types
 ---
-​
+
 This guide shows you how to migrate deprecated configuration types.
 
 ## *dashboard*, *request-naming-service*, *app-detection-rule*

--- a/documentation/versioned_docs/version-1.8.3/commands/experimental-new-cli.md
+++ b/documentation/versioned_docs/version-1.8.3/commands/experimental-new-cli.md
@@ -21,10 +21,10 @@ NEW_CLI=1 monaco
 
 This command is basically doing what the old tool did. It is used to deploy a specified config to a Dynatrace environment.
 The flags to things like the environments files are mostly the same.
-Read more about it here: [Deploy projects](../commands/deploying-projects.md)
+Read more about it here: [Deploy projects](deploying-projects.md)
 
 ### Download
 
 This command allows you to download the configuration from a Dynatrace tenant as Monaco files.
 Use this command to avoid starting from scratch when using Monaco.
-Read more about it here: [Download configuration](../commands/downloading-configuration.md)
+Read more about it here: [Download configuration](downloading-configuration.md)

--- a/documentation/versioned_docs/version-1.8.3/commands/validating-configuration.md
+++ b/documentation/versioned_docs/version-1.8.3/commands/validating-configuration.md
@@ -16,7 +16,7 @@ monaco --dry-run --environments=environments.yaml
 
 ## Validating your configuration using the new CLI
 
-To validate your configuration [using the new CLI](./experimental-new-cli.md), add the `--dry-run` flag to the `deploy` command.
+To validate your configuration [using the new CLI](experimental-new-cli.md), add the `--dry-run` flag to the `deploy` command.
 ```shell title="Validating your configuration using the new CLI"
 NEW_CLI=1 monaco deploy --dry-run --environments=environments.yaml
 ```

--- a/documentation/versioned_docs/version-1.8.3/configuration/configTypes_tokenPermissions.md
+++ b/documentation/versioned_docs/version-1.8.3/configuration/configTypes_tokenPermissions.md
@@ -74,4 +74,4 @@ These are the supported configuration types, their API endpoints and the token p
 For reference, refer to [this](https://www.dynatrace.com/support/help/dynatrace-api/basics/dynatrace-api-authentication) page for a detailed
 description to each token permission.
 
-If your desired API is not in the table above, please consider adding it by following the instructions in [How to add new APIs](Guides/add_new_api.md).
+If your desired API is not in the table above, please consider adding it by following the instructions in [How to add new APIs](/Guides/add_new_api.md).

--- a/documentation/versioned_docs/version-1.8.3/configuration/configuration_structure.md
+++ b/documentation/versioned_docs/version-1.8.3/configuration/configuration_structure.md
@@ -27,9 +27,9 @@ Configs can then be downloaded via the respective GET endpoint defined in the Dy
 Checked-in configuration should **not** include:
 
 * The entity's `id` but only its `name`. The entity may be created or updated if one of the same name exists.
-  * The `name` must be defined as [a variable](#configuration-yaml-structure).
+  * The `name` must be defined as [a variable](yaml_config.md#config-yaml-structure).
 * Hardcoded values for environment information such as references to other auto-deployed entities, tags, management-zones, etc.
-  * These should all be referenced as variables as [described below](#referencing-other-configurations).
+  * These should all be referenced as variables as [described here](yaml_config.md#referencing-other-configurations).
 * Empty/null values that are optional for the creation of an object.
   * Most API GET endpoints return more data than needed to create an object. Many of those fields are empty or null and can be omitted.
   * E.g., `tileFilter`s on dashboards
@@ -41,7 +41,7 @@ The tool handles these files as templates, so you can use the following variable
 ```
 
 
-Variables present in the template need to be defined in the respective config`yaml` - [see 'Configuration YAML Structure'](../configuration/yaml_config).
+Variables present in the template need to be defined in the respective config`yaml` - [see 'Configuration YAML Structure'](yaml_config.md).
 
 ### Dashboard JSON
 
@@ -71,9 +71,9 @@ We recommend the following values for the `dashboardMetadata`:
 ```
 
 This config does the following:
-* Reference the name of the Dashboard as a [variable](../configuration/yaml_config)
+* Reference the name of the Dashboard as a [variable](yaml_config.md)
 * Share the dashboard with other users
-* Set a management zone filter on the complete dashboard, again as a variable, most likely [referenced from another config](../configuration/yaml_config#referencing-other-configurations)
+* Set a management zone filter on the complete dashboard, again as a variable, most likely [referenced from another config](yaml_config.md#referencing-other-configurations)
   * Filtering the whole dashboard by management zone makes sure no private data is accidentally picked up on tiles and removes the possible need to define filters for individual tiles
 
 From Dynatrace version 208 onwards:
@@ -151,7 +151,7 @@ And it also applies to the `SERVICE` type.
 ### Configuration types / APIs
 
 Each type of folder must contain one `configuration yaml` and one or more JSON files containing the actual configuration sent to the Dynatrace API.
-The folder name is case-sensitive and needs to be written exactly as in its definition in [Supported configuration types](../configuration/configTypes_tokenPermissions).
+The folder name is case-sensitive and needs to be written exactly as in its definition in [Supported configuration types](configTypes_tokenPermissions.md).
 
 
 ```

--- a/documentation/versioned_docs/version-1.8.3/configuration/deploy_configuration.md
+++ b/documentation/versioned_docs/version-1.8.3/configuration/deploy_configuration.md
@@ -41,7 +41,7 @@ To deploy to one specific environment within an `environments.yaml` file, the `-
 ```shell
 monaco -e=environments.yaml -se=my-environment -p="my-environment" cluster
 ```
-Read more about the environments file here: [Environments file](./environments_file)
+Read more about the environments file here: [Environments file](environments_file.md)
 
 ### Running the tool with a proxy
 

--- a/documentation/versioned_docs/version-1.8.3/configuration/special_config_types.md
+++ b/documentation/versioned_docs/version-1.8.3/configuration/special_config_types.md
@@ -36,6 +36,6 @@ To work around this, special handling is present for these configuration APIS, e
 As this switch from names to IDs results in re-creating configurations if they were previously created by name,
 already existing configuration types like `dashboard` are retained with the previous flawed handling, while new `-v2` configuration types were added with the non-unique-name constraint/handling.
 
-To ensure configurations are correctly updated, please see the manual steps in the [Migration Guide](Guides/deprecated_migration.md) for how to deal with this.
+To ensure configurations are correctly updated, please see the manual steps in the [Migration Guide](/Guides/deprecated_migration.md) for how to deal with this.
 
 > NOTE: As the `-v2` naming implies, the previous handling is deprecated and will be dropped in version 2.0.

--- a/documentation/versioned_docs/version-1.8.3/configuration/yaml_config.md
+++ b/documentation/versioned_docs/version-1.8.3/configuration/yaml_config.md
@@ -37,7 +37,7 @@ profile:
 
 Every config needs to provide a name for unique identification. Omitting the name variable or using a duplicate name causes a validation / deployment error.
 
-Any defined `{config name}` represents a variable that can then be used in a [JSON template](../configuration/configuration_structure#config-json-templates), and will be resolved and inserted into the config before deploying to Dynatrace.
+Any defined `{config name}` represents a variable that can then be used in a [JSON template](configuration_structure.md#config-json-templates), and will be resolved and inserted into the config before deploying to Dynatrace.
 
 Example: `projects/infrastructure/alerting-profile/profiles.yaml` defines a `name`, which is then used in `projects/infrastructure/alerting-profile/profile.json` as `{{.name}}`.
 

--- a/documentation/versioned_docs/version-1.8.3/documentation.md
+++ b/documentation/versioned_docs/version-1.8.3/documentation.md
@@ -29,18 +29,18 @@ Monaco is a "monitoring as code" tool that allows you to create, update and vers
 
   <li>
 
-[What is Monaco?](./Get-started/intro)
+[What is Monaco?](/Get-started/intro.md)
   </li>
 
 <li>
 
-[Install Monaco](./Get-started/installation)
+[Install Monaco](/Get-started/installation.md)
 
 </li>
 
   <li>
 
-[Deploy configuration](./configuration/deploy_configuration)
+[Deploy configuration](/configuration/deploy_configuration.md)
 
   </li>
 
@@ -60,19 +60,19 @@ Monaco is a "monitoring as code" tool that allows you to create, update and vers
 
   <li>
 
-[Delete configuration](./configuration/delete_config)
+[Delete configuration](/configuration/delete_config.md)
 
   </li>
 
   <li>
 
-[Add a new API](./Guides/add_new_api)
+[Add a new API](/Guides/add_new_api.md)
 
   </li>
 
   <li>
 
-[Activate the new CLI](./commands/experimental-new-cli)
+[Activate the new CLI](/commands/experimental-new-cli.md)
 
   </li>
 
@@ -97,7 +97,7 @@ Monaco is a "monitoring as code" tool that allows you to create, update and vers
 
   <li>
 
-[License and bill of materials](./Useful-links/bill-of-materials)  
+[License and bill of materials](/Useful-links/bill-of-materials.md)  
 
   </li>
 


### PR DESCRIPTION
We had several styles of (relative) links between pages, which occaisonally caused issues. For details on docusaurus linking see: https://docusaurus.io/docs/markdown-features/links

fixes: #738