### PR TITLE
Undo escape all

### DIFF
--- a/cmd/monaco/test-resources/integration-all-configs/project/notification/notifications.yaml
+++ b/cmd/monaco/test-resources/integration-all-configs/project/notification/notifications.yaml
@@ -2,6 +2,7 @@
 config:
   - slack: "subfolder/slack.json"
   - email: "subfolder/email.json"
+  - email_single_receiver: "subfolder/email.json"
 
 slack:
   - alertingProfileId: "/project/alerting-profile/profile.id"
@@ -23,3 +24,9 @@ email.environment1:
 
 email.environment2:
   - environment: "Env2"
+
+email_single_receiver:
+  - name: "There's only one Captain!'s Log"
+  - receivers: '"jim.kirk@dynatrace.com"'
+  - alertingProfileId: "/project/alerting-profile/profile.id"
+  - environment: "test env"

--- a/cmd/monaco/test-resources/special-character-in-config/project/alerting-profile/profile.yaml
+++ b/cmd/monaco/test-resources/special-character-in-config/project/alerting-profile/profile.yaml
@@ -1,6 +1,10 @@
 
 config:
   - profile: "profile.json"
+  - profile2: profile.json
 
 profile:
-  - name: A "Alerting Profile" - for things with "quotes"
+  - name: 'A \"Alerting Profile\" - for things with \"quotes\"'
+
+profile2:
+  - name: Another \"Alerting Profile\" - for things with \"quotes\"

--- a/documentation/docs/configuration/yaml_config.md
+++ b/documentation/docs/configuration/yaml_config.md
@@ -254,3 +254,16 @@ development:
         This will also
         be escaped
 ```
+
+### Double-Quotes in variables
+
+Sometimes you might want to use quotes in a configuration.
+
+To make this work in strings, you need to enclose the value in single-quotes (`'`) and escape any double-quotes (`\"`).
+
+If you don't do that, the fully templated configurations will not be valid JSON.
+
+```yaml
+escaped_quoted_sample:
+    - name: 'An Alerting Profile for \"Company Service\"'
+```

--- a/pkg/util/template_integration_test.go
+++ b/pkg/util/template_integration_test.go
@@ -40,8 +40,8 @@ func TestConfigurationTemplatingFromFilesProducesValidJson(t *testing.T) {
 	assert.NilError(t, err, "Expected template json (%s) to be loaded without error", test_json)
 
 	rendered, err := template.ExecuteTemplate(properties["properties"])
-	assert.NilError(t, err, "Expected template to render without error")
+	assert.NilError(t, err, "Expected template to render without error\n %s", rendered)
 
 	err = ValidateJson(rendered, test_json)
-	assert.NilError(t, err, "Expected rendered template to be valid JSON")
+	assert.NilError(t, err, "Expected rendered template to be valid JSON:\n %s", rendered)
 }

--- a/pkg/util/template_test.go
+++ b/pkg/util/template_test.go
@@ -128,8 +128,7 @@ func TestEscapeNewlineCharacters(t *testing.T) {
 		},
 	}
 
-	result, err := escapeSpecialCharacters(p)
-	assert.NilError(t, err)
+	result := escapeSpecialCharacters(p)
 
 	expected := map[string]interface{}{
 		`string without newline`: `just some string`,
@@ -155,9 +154,8 @@ func TestEscapeNewlineCharactersWithEmptyMap(t *testing.T) {
 
 	empty := map[string]interface{}{}
 
-	res, err := escapeSpecialCharacters(empty)
+	res := escapeSpecialCharacters(empty)
 
-	assert.NilError(t, err)
 	assert.DeepEqual(t, res, empty)
 }
 
@@ -171,10 +169,6 @@ func Test_escapeCharactersForJson(t *testing.T) {
 			`string with no quotes is unchanged`,
 		},
 		{
-			`string """ with "double quotes" results in quotes being "escaped"`,
-			`string \"\"\" with \"double quotes\" results in quotes being \"escaped\"`,
-		},
-		{
 			`string with 'single quotes' quotes is unchanged`,
 			`string with 'single quotes' quotes is unchanged`,
 		},
@@ -184,11 +178,7 @@ func Test_escapeCharactersForJson(t *testing.T) {
 		},
 		{
 			"String with already escaped \\n newline",
-			`String with already escaped \\n newline`,
-		},
-		{
-			"String with one windows\r\nnewline",
-			`String with one windows\r\nnewline`,
+			`String with already escaped \n newline`,
 		},
 		{
 			"String with one\nnewline",
@@ -209,11 +199,7 @@ func Test_escapeCharactersForJson(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.inputString, func(t *testing.T) {
-			got, err := escapeCharactersForJson(tt.inputString)
-			if err != nil {
-				t.Errorf("escapeCharactersForJson() unexpected error = %v", err)
-				return
-			}
+			got := escapeNewlines(tt.inputString)
 			if got != tt.want {
 				t.Errorf("escapeCharactersForJson() got = %v, want %v", got, tt.want)
 			}
@@ -239,17 +225,9 @@ func TestTemplatesWithSpecialCharactersProduceValidJson(t *testing.T) {
 			`{ "key": "{{ .value }}", "object": { "o_key": "{{ .object_value}}" } }`,
 			map[string]string{
 				"value":        "A string\nwith several lines\n\n - here's one\n\n - and another",
-				"object_value": "and\r\none\r\nmore",
+				"object_value": "and\none\nmore",
 			},
-			`{ "key": "A string\nwith several lines\n\n - here's one\n\n - and another", "object": { "o_key": "and\r\none\r\nmore" } }`,
-		},
-		{
-			"strings with random double-quotes are escaped",
-			`{ "key": "{{ .value }}" }`,
-			map[string]string{
-				"value": `A "String" - that contains random "quotes"`,
-			},
-			`{ "key": "A \"String\" - that contains random \"quotes\"" }`,
+			`{ "key": "A string\nwith several lines\n\n - here's one\n\n - and another", "object": { "o_key": "and\none\nmore" } }`,
 		},
 		{
 			"regular slashes are not escaped",
@@ -268,16 +246,14 @@ func TestTemplatesWithSpecialCharactersProduceValidJson(t *testing.T) {
 			`{ "list": [ "element a", "element b", "element c" ] }`,
 		},
 		{
-			"a v1 list definition can still contain newlines",
+			"a list definition can contain newlines",
 			`{ "list": [ {{ .entries }} ] }`,
 			map[string]string{
 				"entries": `"element a",
 "element b",
 "element c"`,
 			},
-			`{ "list": [ "element a",
-"element b",
-"element c" ] }`,
+			"{ \"list\": [ \"element a\",\n\"element b\",\n\"element c\" ] }",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/util/test-resources/templating-integration-test-config.yaml
+++ b/pkg/util/test-resources/templating-integration-test-config.yaml
@@ -1,8 +1,6 @@
 # This is NOT a monaco configuration yaml - it only used to integration test the loading of config from yaml
 properties:
   - simple: "Alpha Quadrant"
-  - string_with_no_quotes: A "Management Zone" - GC name contains "ervice"
-  - string_with_single_quotes: 'A "Management Zone" - GC name contains "ervice"'
   - escaped_with_single_quotes: 'A \"Management Zone\" - GC name contains \"ervice\"'
   - newline1: |-
       ## This is a Markdown tile
@@ -31,6 +29,8 @@ properties:
 
       Same here.
   - list: '"jean-luc.picard@dynatrace.com", "james.t.kirk@dynatrace.com"'
+  - single_entry_list: '"jim.holden@dynatrace.com"'
+  - single_entry_with_quotes_list: "jim.holden@dynatrace.com"
   - list_with_newlines: |
       "jean-luc.picard@dynatrace.com",
       "james.t.kirk@dynatrace.com",

--- a/pkg/util/test-resources/templating-integration-test-template.json
+++ b/pkg/util/test-resources/templating-integration-test-template.json
@@ -2,8 +2,6 @@
     "key": "value",
     "strings": {
         "simple": "{{ .simple }}",
-        "no_quotes": "{{ .string_with_no_quotes }}",
-        "single_quotes": "{{ .string_with_single_quotes }}",
         "escaped_quotes": "{{ .escaped_with_single_quotes }}"
     },
     "newlines": {
@@ -20,6 +18,8 @@
     },
     "lists": {
         "simple" : [ {{ .list }} ],
+        "single_entry" : [ {{ .single_entry_list }} ],
+        "single_entry_with_quotes" : [ "{{ .single_entry_with_quotes_list }}" ],
         "linebreaks_in_json": [
             {{ .list }}
         ],


### PR DESCRIPTION
Reverts functionality of https://github.com/dynatrace-oss/dynatrace-monitoring-as-code/commit/f8d307ceb32100ce357706023aa5745b2cd438af

Handles the original issue resulting in that general fix with a simpler localized change escaping quotes when downloading