### PR TITLE
fix(rest): Log http error and response in case of retry failures

### DIFF
--- a/pkg/rest/config_upload.go
+++ b/pkg/rest/config_upload.go
@@ -240,7 +240,14 @@ func retry(client *http.Client, restCall sendingRequest, objectName string, path
 			return resp, err
 		}
 	}
-	return Response{}, fmt.Errorf("dependency of config %s was not available after %d retries: %w", objectName, maxRetries, err)
+
+	var retryErr error
+	if err != nil {
+		retryErr = fmt.Errorf("dependency of config %s was not available after %d retries: %w", objectName, maxRetries, err)
+	} else {
+		retryErr = fmt.Errorf("dependency of config %s was not available after %d retries: (HTTP %d)!\n    Response was: %s", objectName, maxRetries, resp.StatusCode, resp.Body)
+	}
+	return Response{}, retryErr
 }
 
 func isGeneralDependencyNotReadyYet(resp Response) bool {


### PR DESCRIPTION
Instead of only logging actual errors from the rest call, now log http code and response in the same way non-retried errors are logged.