### PR TITLE
fix(download): Skip plugin-definitions of ad-metrics

### DIFF
--- a/documentation/docs/commands/downloading-configuration.md
+++ b/documentation/docs/commands/downloading-configuration.md
@@ -32,6 +32,19 @@ To download specific APIs only, use `--specific-api` to pass a list of API value
 monaco download --specific-api alerting-profile,dashboard --environments=my-environment.yaml
 ```
 
+# Skipped configurations
+
+Some configurations on Dynatrace are predefined and must not be downloaded and reuploaded on the same, or another environment.
+
+Those skipped configurations are:
+
+| API                         | Details                                                                           |
+|-----------------------------|-----------------------------------------------------------------------------------|
+| `dashboard`/`dashboard-v2`  | Dashboards that have the owner `Dynatrace` set, or dashboards, which are a preset |
+| `anomaly-detection-metrics` | Configurations that start with `dynatrace.` or `ruxit.`                           |
+| `synthetic-locations`       | `public` (Dynatrace provided) locations                                           |
+| `extension`                 | Extensions with an id that starts with `custom.`                                  |
+
 ## Notes
 
 > :warning: **Application Detection Rules.** When using download functionality, you can only update existing application detection rules. You can only create a new app detection rule if no other app detection rules exist for that application.

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -247,6 +247,9 @@ func createConfigsFromAPI(
 		util.Log.Error("error getting client list from api %v %v", api.GetId(), err)
 		return err
 	}
+
+	values = filterConfigsNotToDownload(api, values)
+
 	if len(values) == 0 {
 		util.Log.Info("No elements for API %s", api.GetId())
 		return nil
@@ -316,6 +319,20 @@ func createConfigsFromAPI(
 	}
 
 	return nil
+}
+
+func filterConfigsNotToDownload(a api.Api, values []api.Value) []api.Value {
+	result := make([]api.Value, 0, len(values))
+
+	for _, v := range values {
+		if a.GetId() == "anomaly-detection-metrics" && (strings.HasPrefix(v.Id, "dynatrace.") || strings.HasPrefix(v.Id, "ruxit.")) {
+			util.Log.Debug("Skipping download of config '%v' (%v): Predefined configuration", v.Name, a.GetId())
+		} else {
+			result = append(result, v)
+		}
+	}
+
+	return result
 }
 
 // Retrieves and sanitizes config id which is used as a unique identifier of

--- a/pkg/download/jsoncreator/json_creator.go
+++ b/pkg/download/jsoncreator/json_creator.go
@@ -16,7 +16,6 @@ package jsoncreator
 
 import (
 	"encoding/json"
-	"net/url"
 	"strings"
 
 	"github.com/dynatrace-oss/dynatrace-monitoring-as-code/pkg/api"
@@ -76,23 +75,22 @@ func (d *JsonCreatorImp) CreateJSONConfig(fs afero.Fs, client rest.DynatraceClie
 }
 
 func getDetailFromAPI(client rest.DynatraceClient, api api.Api, entityId string) (dat map[string]interface{}, filter bool, err error) {
-	escapedEntityId := url.QueryEscape(entityId)
 
-	resp, err := client.ReadById(api, escapedEntityId)
+	resp, err := client.ReadById(api, entityId)
 	if err != nil {
-		util.Log.Error("error getting detail for API %s for entity %v", api.GetId(), escapedEntityId)
+		util.Log.Error("error getting detail for API %s for entity %v", api.GetId(), entityId)
 		return nil, false, err
 	}
 
 	err = json.Unmarshal(resp, &dat)
 	if err != nil {
-		util.Log.Error("error transforming %s from json to object", escapedEntityId)
+		util.Log.Error("error transforming %s from json to object", entityId)
 		return nil, false, err
 	}
 
 	filter = isDefaultEntity(api.GetId(), dat)
 	if filter {
-		util.Log.Debug("Non-user-created default Object has been filtered out", escapedEntityId)
+		util.Log.Debug("Non-user-created default Object has been filtered out", entityId)
 		return nil, true, err
 	}
 


### PR DESCRIPTION
Anomaly-detection-metrics that start with dynatrace.* or ruxit.* are metrics that plugins define - we need to skip those during download.