### PR TITLE
docs: Add additional information about name configuration

### DIFF
--- a/documentation/docs/configuration/configuration_structure.md
+++ b/documentation/docs/configuration/configuration_structure.md
@@ -27,7 +27,7 @@ Configs can then be downloaded via the respective GET endpoint defined in the Dy
 Checked-in configuration should **not** include:
 
 * The entity's `id` but only its `name`. The entity may be created or updated if one of the same name exists.
-  * The `name` must be defined as [a variable](yaml_config.md#config-yaml-structure).
+  * The `name` must be defined as [a variable](yaml_config.md#name-variable).
 * Hardcoded values for environment information such as references to other auto-deployed entities, tags, management-zones, etc.
   * These should all be referenced as variables as [described here](yaml_config.md#referencing-other-configurations).
 * Empty/null values that are optional for the creation of an object.
@@ -71,7 +71,7 @@ We recommend the following values for the `dashboardMetadata`:
 ```
 
 This config does the following:
-* Reference the name of the Dashboard as a [variable](yaml_config.md)
+* Reference the name of the Dashboard as a [variable](yaml_config.md#name-variable)
 * Share the dashboard with other users
 * Set a management zone filter on the complete dashboard, again as a variable, most likely [referenced from another config](yaml_config.md#referencing-other-configurations)
   * Filtering the whole dashboard by management zone makes sure no private data is accidentally picked up on tiles and removes the possible need to define filters for individual tiles

--- a/documentation/docs/configuration/yaml_config.md
+++ b/documentation/docs/configuration/yaml_config.md
@@ -34,10 +34,8 @@ profile:
 [...]
 ```
 
-
-Every config needs to provide a name for unique identification. Omitting the name variable or using a duplicate name causes a validation / deployment error.
-
-Any defined `{config name}` represents a variable that can then be used in a [JSON template](configuration_structure.md#config-json-templates), and will be resolved and inserted into the config before deploying to Dynatrace.
+Any defined `- {key} : {value}` for a configuration represents a variable that can then be used in a [JSON template](configuration_structure.md#config-json-templates) by referencing
+the `{key}`. This will be resolved and the `{value}` inserted into the JSON before deploying to Dynatrace.
 
 Example: `projects/infrastructure/alerting-profile/profiles.yaml` defines a `name`, which is then used in `projects/infrastructure/alerting-profile/profile.json` as `{{.name}}`.
 
@@ -49,6 +47,31 @@ profile:
 [...]
 ```
 
+### Name Variable
+**Every config needs to provide a `name` for unique identification.** 
+
+**Omitting the `name` variable or using a duplicate name causes a validation / deployment error.**
+
+The `name` is used to identify configurations on a Dynatrace environment and ensure that they are updated when they already exist. 
+
+For this, the `name` needs to be used in the [JSON template](configuration_structure.md#config-json-templates) to fill the specific name property of the configuration. 
+Usually this is also just `name`, but for some configurations this may differ - please see the special cases described for [JSON templates](configuration_structure.md#config-json-templates) and refer to the [Dynatrace API documentation](https://www.dynatrace.com/support/help/dynatrace-api) if in doubt.
+
+> When [downloading](/commands/downloading-configuration.md) names will be automatically extracted and placed in the YAML for you!
+
+When referencing the `name` in a JSON Template it needs to be used as is, with no additional characters around it. See the single correct sample in the table below:
+
+| Name property in JSON            | Correct |
+|----------------------------------|---------|
+| `"{{ .name }}"`                  | ✅       |
+| `" {{ .name }}"`                 | ❌      |
+| `"{{ .name }} "`                 | ❌      |
+| `"Some extra text: {{ .name }}"` | ❌      |
+
+
+> Should you encounter issues of configurations not being created several times instead of updated,
+> check that your reference to the name does not contain any accidental spaces or other characters making
+> what is sent to Dynatrace in the JSON different from the name defined in the YAML!
 
 
 ### Skip configuration deployment

--- a/documentation/versioned_docs/version-1.8.x/configuration/configuration_structure.md
+++ b/documentation/versioned_docs/version-1.8.x/configuration/configuration_structure.md
@@ -27,7 +27,7 @@ Configs can then be downloaded via the respective GET endpoint defined in the Dy
 Checked-in configuration should **not** include:
 
 * The entity's `id` but only its `name`. The entity may be created or updated if one of the same name exists.
-  * The `name` must be defined as [a variable](yaml_config.md#config-yaml-structure).
+  * The `name` must be defined as [a variable](yaml_config.md#name-variable).
 * Hardcoded values for environment information such as references to other auto-deployed entities, tags, management-zones, etc.
   * These should all be referenced as variables as [described here](yaml_config.md#referencing-other-configurations).
 * Empty/null values that are optional for the creation of an object.
@@ -71,7 +71,7 @@ We recommend the following values for the `dashboardMetadata`:
 ```
 
 This config does the following:
-* Reference the name of the Dashboard as a [variable](yaml_config.md)
+* Reference the name of the Dashboard as a [variable](yaml_config.md#name-variable)
 * Share the dashboard with other users
 * Set a management zone filter on the complete dashboard, again as a variable, most likely [referenced from another config](yaml_config.md#referencing-other-configurations)
   * Filtering the whole dashboard by management zone makes sure no private data is accidentally picked up on tiles and removes the possible need to define filters for individual tiles

--- a/documentation/versioned_docs/version-1.8.x/configuration/yaml_config.md
+++ b/documentation/versioned_docs/version-1.8.x/configuration/yaml_config.md
@@ -34,10 +34,8 @@ profile:
 [...]
 ```
 
-
-Every config needs to provide a name for unique identification. Omitting the name variable or using a duplicate name causes a validation / deployment error.
-
-Any defined `{config name}` represents a variable that can then be used in a [JSON template](configuration_structure.md#config-json-templates), and will be resolved and inserted into the config before deploying to Dynatrace.
+Any defined `- {key} : {value}` for a configuration represents a variable that can then be used in a [JSON template](configuration_structure.md#config-json-templates) by referencing
+the `{key}`. This will be resolved and the `{value}` inserted into the JSON before deploying to Dynatrace.
 
 Example: `projects/infrastructure/alerting-profile/profiles.yaml` defines a `name`, which is then used in `projects/infrastructure/alerting-profile/profile.json` as `{{.name}}`.
 
@@ -49,6 +47,31 @@ profile:
 [...]
 ```
 
+### Name Variable
+**Every config needs to provide a `name` for unique identification.** 
+
+**Omitting the `name` variable or using a duplicate name causes a validation / deployment error.**
+
+The `name` is used to identify configurations on a Dynatrace environment and ensure that they are updated when they already exist. 
+
+For this, the `name` needs to be used in the [JSON template](configuration_structure.md#config-json-templates) to fill the specific name property of the configuration. 
+Usually this is also just `name`, but for some configurations this may differ - please see the special cases described for [JSON templates](configuration_structure.md#config-json-templates) and refer to the [Dynatrace API documentation](https://www.dynatrace.com/support/help/dynatrace-api) if in doubt.
+
+> When [downloading](/commands/downloading-configuration.md) names will be automatically extracted and placed in the YAML for you!
+
+When referencing the `name` in a JSON Template it needs to be used as is, with no additional characters around it. See the single correct sample in the table below:
+
+| Name property in JSON            | Correct |
+|----------------------------------|---------|
+| `"{{ .name }}"`                  | ✅       |
+| `" {{ .name }}"`                 | ❌      |
+| `"{{ .name }} "`                 | ❌      |
+| `"Some extra text: {{ .name }}"` | ❌      |
+
+
+> Should you encounter issues of configurations not being created several times instead of updated,
+> check that your reference to the name does not contain any accidental spaces or other characters making
+> what is sent to Dynatrace in the JSON different from the name defined in the YAML!
 
 
 ### Skip configuration deployment


### PR DESCRIPTION
Name parameters where so far only mentioned in passing, but an integral part of how monaco works.
Add some more details about configuring them and detail common pitfals of wrongly using the name variable inside a JSON template.