### PR TITLE
fix: Correctly configure location for synthetic test config

### DIFF
--- a/cmd/monaco/test-resources/special-character-in-config/project/synthetic-monitor/availability.json
+++ b/cmd/monaco/test-resources/special-character-in-config/project/synthetic-monitor/availability.json
@@ -25,5 +25,8 @@
           }
         }
       ]
-    }
+    },
+    "locations": [
+        "{{ .location }}"
+    ]
   }

--- a/cmd/monaco/test-resources/special-character-in-config/project/synthetic-monitor/synthetic-monitors.yaml
+++ b/cmd/monaco/test-resources/special-character-in-config/project/synthetic-monitor/synthetic-monitors.yaml
@@ -1,6 +1,7 @@
-config: 
+config:
   - availability: "availability.json"
 
 availability:
   - name: "Dynatrace Homepage Check"
   - ua_string: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36"
+  - location: "GEOLOCATION-9999453BE4BDB3CD"


### PR DESCRIPTION
The synthetic test json used in the special-characters tests was actually incorrect as it was not setting the required locations property.

A synthetic without a single location to run it from does not really make sense, and is also validated against by the UI and (as of recently) the API.